### PR TITLE
docs(README): update link to upstream iOS Getting Started Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Before you can run the project, follow the [Getting Started Guide](https://devel
 
 #### 3.2 iOS
 
-Follow ***steps 3 and 4*** in the [Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started/?sdk=cocoapods) for Facebook SDK for iOS.
+Follow ***steps 3 and 4*** in the [Getting Started Guide](https://developers.facebook.com/docs/ios/use-cocoapods) for Facebook SDK for iOS.
 
 **If you're not using cocoapods already** you can also follow step 1.1 to set it up.
 


### PR DESCRIPTION
The old link is broken. This updates to the correct link. We might change the step numbers because step 3 isn't reflected in the guide for some reason. 
