### PR TITLE
fix: compileDebugJavaWithJavac

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
@@ -16,6 +16,10 @@ import androidx.annotation.NonNull;
 public class FBProfileModule extends ReactContextBaseJavaModule {
     public static final String NAME = "FBProfile";
 
+    public FBProfileModule(@NonNull ReactApplicationContext reactContext) {
+      super(reactContext);
+    }
+
     @NonNull
     @Override
     public String getName() {

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.annotations.ReactModule;
 
 import androidx.annotation.NonNull;

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
@@ -16,7 +16,7 @@ import androidx.annotation.NonNull;
 public class FBProfileModule extends ReactContextBaseJavaModule {
     public static final String NAME = "FBProfile";
 
-    public FBProfileModule(@NonNull ReactApplicationContext reactContext) {
+    public FBProfileModule(ReactApplicationContext reactContext) {
       super(reactContext);
     }
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -43,7 +43,7 @@ public class FBSDKPackage implements ReactPackage {
                 new FBGraphRequestModule(reactContext),
                 new FBLoginManagerModule(reactContext, mActivityEventListener),
                 new FBMessageDialogModule(reactContext, mActivityEventListener),
-                new FBProfileModule(),
+                new FBProfileModule(reactContext),
                 new FBSettingsModule(),
                 new FBShareDialogModule(reactContext, mActivityEventListener)
         );


### PR DESCRIPTION
Propose to fix a build error in android. Missing constructor on FacebookProfile.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
thebergamo#30

Test Plan:
In a project with react-native-fbsdk-next as dependency enter in android folder and run:
cd android && ./gradlew app:installDebug -PreactNativeDevServerPort=8081
