### PR TITLE
Update index.js to import react-native-fbsdk-next

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -5,7 +5,7 @@
 import {AppRegistry, Platform} from 'react-native';
 import App from './src/App';
 import {name as appName} from './app.json';
-import {Settings} from 'react-native-fbsdk';
+import {Settings} from 'react-native-fbsdk-next';
 
 /**
  * The `autoInitEnabled` option is removed from facebook-ios-sdk, should initialize manually


### PR DESCRIPTION
The example is using `react-native-fbsdk` instead of `react-native-fbsdk-next` so I just thought I'd update that. It still doesn't run for me (see #21) but I thought I'd help out where I can for now as I do not know how to resolve the `InvariantViolation`