### PR TITLE
fix(android, event-emitter): add required event listener stubs for react-native 0.65

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
@@ -105,6 +105,16 @@ public class FBAccessTokenModule extends ReactContextBaseJavaModule {
         AccessToken.setCurrentAccessToken(accessToken);
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     /**
      * Updates the current access token with up to date permissions, and extends the expiration
      * date, if extension is possible.


### PR DESCRIPTION
These are needed to avoid console warnings about NativeEventEmitter being
created without the required native module implementations

Test Plan:

It's impossible for these methods to have bugs because they're just stubs ;-)

I've integrated it locally via patch-package, and it's the same change I've successfully made + released in react-native-firebase and react-native-device-info, as well as patched locally in netinfo (PR there is merged but not released yet).
