### PR TITLE
fix: NSStringArray warnings

### DIFF
--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -33,12 +33,12 @@ RCT_EXPORT_METHOD(setAdvertiserTrackingEnabled:(BOOL)ATE resolver:(RCTPromiseRes
   resolve(@(result));
 }
 
-RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSStringArray *)options)
+RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options)
 {
   [FBSDKSettings setDataProcessingOptions:options];
 }
 
-RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSStringArray *)options country:(int)country state:(int)state)
+RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options country:(int)country state:(int)state)
 {
   [FBSDKSettings setDataProcessingOptions:options country:country state:state];
 }


### PR DESCRIPTION
fix Xcode build warnings: `'NSStringArray' is deprecated: Use NSArray<NSString *>`
sync types with [facebook-ios-sdk](https://github.com/facebook/facebook-ios-sdk/blob/main/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.m#L433)