### PR TITLE
feat: add logProductItem

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -38,6 +38,7 @@ import com.facebook.react.module.annotations.ReactModule;
 import java.math.BigDecimal;
 import java.util.Currency;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -141,7 +142,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void setFlushBehavior(String flushBehavior) {
-        AppEventsLogger.setFlushBehavior(AppEventsLogger.FlushBehavior.valueOf(flushBehavior.toUpperCase()));
+        AppEventsLogger.setFlushBehavior(AppEventsLogger.FlushBehavior.valueOf(flushBehavior.toUpperCase(Locale.ROOT)));
     }
 
     /**
@@ -232,8 +233,8 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
                                String brand,
                                Bundle parameters) {
         mAppEventLogger.logProductItem(itemID,
-                AppEventsLogger.ProductAvailability.valueOf(availability.toUpperCase()),
-                AppEventsLogger.ProductCondition.valueOf(condition.toUpperCase()),
+                AppEventsLogger.ProductAvailability.valueOf(availability.toUpperCase(Locale.ROOT)),
+                AppEventsLogger.ProductCondition.valueOf(condition.toUpperCase(Locale.ROOT)),
                 description,
                 imageLink,
                 link,

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -20,6 +20,8 @@
 
 package com.facebook.reactnative.androidsdk;
 
+import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 
 import com.facebook.appevents.AppEventsConstants;
@@ -197,6 +199,52 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      public void logPushNotificationOpen(@Nullable ReadableMap payload) {
          mAppEventLogger.logPushNotificationOpen(Arguments.toBundle(payload));
      }
+
+    /**
+     * Uploads product catalog product item as an app event.
+     *
+     * @param itemID – Unique ID for the item. Can be a variant for a product. Max size is 100.
+     * @param availability – If item is in stock. Accepted values are: in stock - Item ships immediately out of stock - No plan to restock preorder - Available in future available for order - Ships in 1-2 weeks discontinued - Discontinued
+     * @param condition – Product condition: new, refurbished or used.
+     * @param description – Short text describing product. Max size is 5000.
+     * @param imageLink – Link to item image used in ad.
+     * @param link – Link to merchant's site where someone can buy the item.
+     * @param title – Title of item.
+     * @param priceAmount – Amount of purchase, in the currency specified by the 'currency' parameter. This value will be rounded to the thousandths place (e.g., 12.34567 becomes 12.346).
+     * @param currency – Currency used to specify the amount.
+     * @param gtin – Global Trade Item Number including UPC, EAN, JAN and ISBN
+     * @param mpn – Unique manufacture ID for product
+     * @param brand – Name of the brand Note: Either gtin, mpn or brand is required.
+     * @param parameters – Optional fields for deep link specification.
+     */
+    @ReactMethod
+    public void logProductItem(String itemID,
+                               String availability,
+                               String condition,
+                               String description,
+                               String imageLink,
+                               String link,
+                               String title,
+                               BigDecimal priceAmount,
+                               Currency currency,
+                               String gtin,
+                               String mpn,
+                               String brand,
+                               Bundle parameters) {
+        mAppEventLogger.logProductItem(itemID,
+                AppEventsLogger.ProductAvailability.valueOf(availability.toUpperCase()),
+                AppEventsLogger.ProductCondition.valueOf(condition.toUpperCase()),
+                description,
+                imageLink,
+                link,
+                title,
+                priceAmount,
+                currency,
+                gtin,
+                mpn,
+                brand,
+                parameters);
+    }
 
     /**
      * Sets a user id to associate with all app events. This can be used to associate your own

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -212,7 +212,7 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      * @param link – Link to merchant's site where someone can buy the item.
      * @param title – Title of item.
      * @param priceAmount – Amount of purchase, in the currency specified by the 'currency' parameter. This value will be rounded to the thousandths place (e.g., 12.34567 becomes 12.346).
-     * @param currency – Currency used to specify the amount.
+     * @param currencyCode – Currency used to specify the amount.
      * @param gtin – Global Trade Item Number including UPC, EAN, JAN and ISBN
      * @param mpn – Unique manufacture ID for product
      * @param brand – Name of the brand Note: Either gtin, mpn or brand is required.
@@ -226,12 +226,12 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
                                String imageLink,
                                String link,
                                String title,
-                               BigDecimal priceAmount,
-                               Currency currency,
+                               double priceAmount,
+                               String currencyCode,
                                String gtin,
                                String mpn,
                                String brand,
-                               Bundle parameters) {
+                               @Nullable ReadableMap parameters) {
         mAppEventLogger.logProductItem(itemID,
                 AppEventsLogger.ProductAvailability.valueOf(availability.toUpperCase(Locale.ROOT)),
                 AppEventsLogger.ProductCondition.valueOf(condition.toUpperCase(Locale.ROOT)),
@@ -239,12 +239,12 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
                 imageLink,
                 link,
                 title,
-                priceAmount,
-                currency,
+                BigDecimal.valueOf(priceAmount),
+                Currency.getInstance(currencyCode),
                 gtin,
                 mpn,
                 brand,
-                parameters);
+                Arguments.toBundle(parameters));
     }
 
     /**

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -30,6 +30,20 @@ RCT_ENUM_CONVERTER(FBSDKAppEventsFlushBehavior, (@{
   @"explicit_only": @(FBSDKAppEventsFlushBehaviorExplicitOnly),
 }), FBSDKAppEventsFlushBehaviorAuto, unsignedIntegerValue)
 
+RCT_ENUM_CONVERTER(FBSDKProductAvailability, (@{
+  @"in_stock": @(FBSDKProductAvailabilityInStock),
+  @"out_of_stock": @(FBSDKProductAvailabilityOutOfStock),
+  @"preorder": @(FBSDKProductAvailabilityPreOrder),
+  @"avaliable_for_order": @(FBSDKProductAvailabilityAvailableForOrder),
+  @"discontinued": @(FBSDKProductAvailabilityDiscontinued),
+}), FBSDKProductAvailabilityInStock, unsignedIntegerValue)
+
+RCT_ENUM_CONVERTER(FBSDKProductCondition, (@{
+  @"new": @(FBSDKProductConditionNew),
+  @"refurbished": @(FBSDKProductConditionRefurbished),
+  @"used": @(FBSDKProductConditionUsed),
+}), FBSDKProductConditionNew, unsignedIntegerValue)
+
 @end
 
 @implementation RCTFBSDKAppEvents
@@ -65,6 +79,35 @@ RCT_EXPORT_METHOD(logPurchase:(double)purchaseAmount
                      currency:currency
                    parameters:parameters
                   accessToken:nil];
+}
+
+RCT_EXPORT_METHOD(logProductItem:(NSString *)itemID
+                    availability:(FBSDKProductAvailability)availability
+                       condition:(FBSDKProductCondition)condition
+                     description:(NSString *)description
+                       imageLink:(NSString *)imageLink
+                            link:(NSString *)link
+                           title:(NSString *)title
+                     priceAmount:(double)priceAmount
+                        currency:(NSString *)currency
+                            gtin:(NSString *)gtin
+                             mpn:(NSString *)mpn
+                           brand:(NSString *)brand
+                      parameters:(NSDictionary *)parameters)
+{
+    [FBSDKAppEvents logProductItem:itemID
+                      availability:availability
+                         condition:condition
+                       description:description
+                         imageLink:imageLink
+                              link:link
+                             title:title
+                       priceAmount:priceAmount
+                          currency:currency
+                              gtin:gtin
+                               mpn:mpn
+                             brand:brand
+                        parameters:parameters];
 }
 
 RCT_EXPORT_METHOD(logPushNotificationOpen:(NSDictionary *)payload)

--- a/src/FBAppEventsLogger.js
+++ b/src/FBAppEventsLogger.js
@@ -24,6 +24,7 @@
 
 const AppEventsLogger = require('react-native').NativeModules.FBAppEventsLogger;
 const {Platform} = require('react-native');
+
 /**
  * Controls when an AppEventsLogger sends log events to the server
  */
@@ -37,6 +38,37 @@ type AppEventsFlushBehavior =
    * Only flush when AppEventsLogger.flush() is explicitly invoked.
    */
   | 'explicit_only';
+
+/**
+ * Specifies product availability for Product Catalog product item update
+ */
+type ProductAvailability =
+  /**
+   * Item ships immediately
+   */
+  | 'in_stock'
+  /**
+   * No plan to restock
+   */
+  | 'out_of_stock'
+  /**
+   * Available in future
+   */
+  | 'preorder'
+  /**
+   * Ships in 1-2 weeks
+   */
+  | 'avaliable_for_order'
+  /**
+   * Discontinued
+   */
+  | 'discontinued';
+
+/**
+ * Specifies product condition for Product Catalog product item update
+ */
+type ProductCondition = 'new' | 'refurbished' | 'used';
+
 type Params = {[key: string]: string | number};
 
 /**
@@ -156,6 +188,58 @@ module.exports = {
    */
   logPushNotificationOpen(payload: ?Object) {
     AppEventsLogger.logPushNotificationOpen(payload);
+  },
+
+  /**
+   * Uploads product catalog product item as an app event
+   * @param itemID – Unique ID for the item. Can be a variant for a product. Max size is 100.
+   * @param availability – If item is in stock. Accepted values are: in stock - Item ships immediately out of stock - No plan to restock preorder - Available in future available for order - Ships in 1-2 weeks discontinued - Discontinued
+   * @param condition – Product condition: new, refurbished or used.
+   * @param description – Short text describing product. Max size is 5000.
+   * @param imageLink – Link to item image used in ad.
+   * @param link – Link to merchant's site where someone can buy the item.
+   * @param title – Title of item.
+   * @param priceAmount – Amount of purchase, in the currency specified by the 'currency' parameter. This value will be rounded to the thousandths place (e.g., 12.34567 becomes 12.346).
+   * @param currency – Currency used to specify the amount.
+   * @param gtin – Global Trade Item Number including UPC, EAN, JAN and ISBN
+   * @param mpn – Unique manufacture ID for product
+   * @param brand – Name of the brand Note: Either gtin, mpn or brand is required.
+   * @param parameters – Optional fields for deep link specification.
+   */
+  logProductItem(
+    itemID: string,
+    availability: ProductAvailability,
+    condition: ProductCondition,
+    description: string,
+    imageLink: string,
+    link: string,
+    title: string,
+    priceAmount: number,
+    currency: string,
+    gtin?: ?string,
+    mpn?: ?string,
+    brand?: ?string,
+    parameters?: ?Params,
+  ) {
+    if (!gtin && !mpn && !brand) {
+      throw new Error('Either gtin, mpn or brand is required');
+    }
+
+    AppEventsLogger.logProductItem(
+      itemID,
+      availability,
+      condition,
+      description,
+      imageLink,
+      link,
+      title,
+      priceAmount,
+      currency,
+      gtin,
+      mpn,
+      brand,
+      parameters,
+    );
   },
 
   /**

--- a/src/FBAppEventsLogger.js
+++ b/src/FBAppEventsLogger.js
@@ -24,6 +24,7 @@
 
 const AppEventsLogger = require('react-native').NativeModules.FBAppEventsLogger;
 const {Platform} = require('react-native');
+const {isDefined, isNumber, isOneOf, isString} = require('./util/validate');
 
 /**
  * Controls when an AppEventsLogger sends log events to the server
@@ -221,8 +222,53 @@ module.exports = {
     brand?: ?string,
     parameters?: ?Params,
   ) {
-    if (!gtin && !mpn && !brand) {
-      throw new Error('Either gtin, mpn or brand is required');
+    if (!isDefined(itemID) || !isString(itemID)) {
+      throw new Error("logProductItem expected 'itemID' to be a string");
+    }
+    if (
+      !isDefined(availability) ||
+      !isOneOf(availability, [
+        'in_stock',
+        'out_of_stock',
+        'preorder',
+        'avaliable_for_order',
+        'discontinued',
+      ])
+    ) {
+      throw new Error(
+        "logProductItem expected 'availability' to be one of 'in_stock' | 'out_of_stock' | 'preorder' | 'avaliable_for_order' | 'discontinued'",
+      );
+    }
+    if (
+      !isDefined(condition) ||
+      !isOneOf(condition, ['new', 'refurbished', 'used'])
+    ) {
+      throw new Error(
+        "logProductItem expected 'condition' to be one of 'new' | 'refurbished' | 'used'",
+      );
+    }
+    if (!isDefined(description) || !isString(description)) {
+      throw new Error("logProductItem expected 'description' to be a string");
+    }
+    if (!isDefined(imageLink) || !isString(imageLink)) {
+      throw new Error("logProductItem expected 'imageLink' to be a string");
+    }
+    if (!isDefined(link) || !isString(link)) {
+      throw new Error("logProductItem expected 'link' to be a string");
+    }
+    if (!isDefined(title) || !isString(title)) {
+      throw new Error("logProductItem expected 'title' to be a string");
+    }
+    if (!isDefined(priceAmount) || !isNumber(priceAmount)) {
+      throw new Error("logProductItem expected 'priceAmount' to be a number");
+    }
+    if (!isDefined(currency) || !isString(currency)) {
+      throw new Error("logProductItem expected 'currency' to be a string");
+    }
+    if (!isDefined(gtin) && !isDefined(mpn) && !isDefined(brand)) {
+      throw new Error(
+        'logProductItem expected either gtin, mpn or brand to be defined',
+      );
     }
 
     AppEventsLogger.logProductItem(

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Taken from react-native-firebase: https://github.com/invertase/react-native-firebase/blob/master/packages/app/lib/common/validate.js
+ */
+
+const AlphaNumericUnderscore = /^[a-zA-Z0-9_]+$/;
+
+export function objectKeyValuesAreStrings(object) {
+  if (!isObject(object)) {
+    return false;
+  }
+
+  const entries = Object.entries(object);
+
+  for (let i = 0; i < entries.length; i++) {
+    const [key, value] = entries[i];
+    if (!isString(key) || !isString(value)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Simple is null check.
+ *
+ * @param value
+ * @returns {boolean}
+ */
+export function isNull(value) {
+  return value === null;
+}
+
+/**
+ * Simple is object check.
+ *
+ * @param value
+ * @returns {boolean}
+ */
+export function isObject(value) {
+  return value ? typeof value === 'object' && !Array.isArray(value) && !isNull(value) : false;
+}
+
+/**
+ * Simple is date check
+ * https://stackoverflow.com/a/44198641
+ * @param value
+ * @returns {boolean}
+ */
+export function isDate(value) {
+  // use the global isNaN() and not Number.isNaN() since it will validate an Invalid Date
+  return value && Object.prototype.toString.call(value) === '[object Date]' && !isNaN(value);
+}
+
+/**
+ * Simple is function check
+ *
+ * @param value
+ * @returns {*|boolean}
+ */
+export function isFunction(value) {
+  return value ? typeof value === 'function' : false;
+}
+
+/**
+ * Simple is string check
+ * @param value
+ * @return {boolean}
+ */
+export function isString(value) {
+  return typeof value === 'string';
+}
+
+/**
+ * Simple is number check
+ * @param value
+ * @return {boolean}
+ */
+export function isNumber(value) {
+  return typeof value === 'number';
+}
+
+/**
+ * Simple finite check
+ * @param value
+ * @returns {boolean}
+ */
+export function isFinite(value) {
+  return Number.isFinite(value);
+}
+
+/**
+ * Simple integer check
+ * @param value
+ * @returns {boolean}
+ */
+export function isInteger(value) {
+  return Number.isInteger(value);
+}
+
+/**
+ * Simple is boolean check
+ *
+ * @param value
+ * @return {boolean}
+ */
+export function isBoolean(value) {
+  return typeof value === 'boolean';
+}
+
+/**
+ *
+ * @param value
+ * @returns {arg is Array<any>}
+ */
+export function isArray(value) {
+  return Array.isArray(value);
+}
+
+/**
+ *
+ * @param value
+ * @returns {boolean}
+ */
+export function isUndefined(value) {
+  return typeof value === 'undefined';
+}
+
+/**
+ *
+ * @param value
+ * @returns {boolean}
+ */
+ export function isDefined(value) {
+  return !isNull(value) && !isUndefined(value);
+}
+
+/**
+ * /^[a-zA-Z0-9_]+$/
+ *
+ * @param value
+ * @returns {boolean}
+ */
+export function isAlphaNumericUnderscore(value) {
+  return AlphaNumericUnderscore.test(value);
+}
+
+/**
+ * URL test
+ * @param url
+ * @returns {boolean}
+ */
+const IS_VALID_URL_REGEX = /^(http|https):\/\/[^ "]+$/;
+export function isValidUrl(url) {
+  return IS_VALID_URL_REGEX.test(url);
+}
+
+/**
+ * Array includes
+ *
+ * @param value
+ * @param oneOf
+ * @returns {boolean}
+ */
+export function isOneOf(value, oneOf = []) {
+  if (!isArray(oneOf)) {
+    return false;
+  }
+  return oneOf.includes(value);
+}
+
+export function noop() {
+  // noop-🐈
+}

--- a/types/FBAppEventsLogger.d.ts
+++ b/types/FBAppEventsLogger.d.ts
@@ -11,6 +11,34 @@ type AppEventsFlushBehavior =
  * Only flush when AppEventsLogger.flush() is explicitly invoked.
  */
 | 'explicit_only';
+/**
+ * Specifies product availability for Product Catalog product item update
+ */
+type ProductAvailability =
+  /**
+   * Item ships immediately
+   */
+  | 'in_stock'
+  /**
+   * No plan to restock
+   */
+  | 'out_of_stock'
+  /**
+   * Available in future
+   */
+  | 'preorder'
+  /**
+   * Ships in 1-2 weeks
+   */
+  | 'avaliable_for_order'
+  /**
+   * Discontinued
+   */
+  | 'discontinued';
+/**
+ * Specifies product condition for Product Catalog product item update
+ */
+type ProductCondition = 'new' | 'refurbished' | 'used';
 type Params = {
   [key: string]: string | number;
 };
@@ -98,6 +126,37 @@ export type FBAppEventsLogger = {
      * Logs an app event that tracks that the application was open via Push Notification.
      */
   logPushNotificationOpen(payload?: any | null): void;
+  /**
+   * Uploads product catalog product item as an app event
+   * @param itemID – Unique ID for the item. Can be a variant for a product. Max size is 100.
+   * @param availability – If item is in stock. Accepted values are: in stock - Item ships immediately out of stock - No plan to restock preorder - Available in future available for order - Ships in 1-2 weeks discontinued - Discontinued
+   * @param condition – Product condition: new, refurbished or used.
+   * @param description – Short text describing product. Max size is 5000.
+   * @param imageLink – Link to item image used in ad.
+   * @param link – Link to merchant's site where someone can buy the item.
+   * @param title – Title of item.
+   * @param priceAmount – Amount of purchase, in the currency specified by the 'currency' parameter. This value will be rounded to the thousandths place (e.g., 12.34567 becomes 12.346).
+   * @param currency – Currency used to specify the amount.
+   * @param gtin – Global Trade Item Number including UPC, EAN, JAN and ISBN
+   * @param mpn – Unique manufacture ID for product
+   * @param brand – Name of the brand Note: Either gtin, mpn or brand is required.
+   * @param parameters – Optional fields for deep link specification.
+   */
+  logProductItem(
+    itemID: string,
+    availability: ProductAvailability,
+    condition: ProductCondition,
+    description: string,
+    imageLink: string,
+    link: string,
+    title: string,
+    priceAmount: number,
+    currency: string,
+    gtin?: string | null | undefined,
+    mpn?: string | null | undefined,
+    brand?: string | null | undefined,
+    parameters?: Params | null | undefined,
+  );
   /**
      * Explicitly kicks off flushing of events to Facebook.
      */


### PR DESCRIPTION
This function has been on both android & ios native SDKs for a couple of years now... just exposing it to RN land

**Test plan**
used this branch on our app and logged some events, validated they show up on Facebook's Events Manager debugger view:

iOS
<p align="center">
<img src="https://user-images.githubusercontent.com/6749415/134402777-5926aac1-d420-44e1-80d6-d522fa5c15ac.png" width="400" />
</p>
Android
<p align="center">
<img src="https://user-images.githubusercontent.com/6749415/134402805-4b5a71f5-4715-4023-8c95-f48856a16715.png" width="400" />
</p>