### PR TITLE
docs(README): update troubleshooting session in readme to include fix to 'AppId not found'

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,14 @@ $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)
    
    Both the Facebook App and your app have to have App Tracking Transparency (ATT) permission granted for facebook deferred app links to work. See [this related issue](https://github.com/thebergamo/react-native-fbsdk-next/issues/104#issuecomment-931488609)
   
+6. You get an exception `App ID not found. Add a string value with your app ID for the key FacebookAppID to the Info.plist or call [FBSDKSettings setAppID:].`
 
+  If you find yourself in this situation, head over to your `AppDelegate.m` file and add the following lines inside the `- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions`, just before the `return YES` statement: 
+
+  ```
+    [[FBSDKApplicationDelegate sharedInstance] application:application
+                           didFinishLaunchingWithOptions:launchOptions];
+  ```
 ## Usage
 
 ### SDK Initialization

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)
   
 6. You get an exception `App ID not found. Add a string value with your app ID for the key FacebookAppID to the Info.plist or call [FBSDKSettings setAppID:].`
 
-  If you find yourself in this situation, head over to your `AppDelegate.m` file and add the following lines inside the `- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions`, just before the `return YES` statement: 
+  If you find yourself in this situation, and you are certain that you have the FacebookAppID in your Info.plist or that you have called `setAppId`, you *may* be able to fix it by adding the following lines to `AppDelegate.m` inside the `- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions`, just before the `return YES` statement: 
 
   ```
     [[FBSDKApplicationDelegate sharedInstance] application:application


### PR DESCRIPTION
Hey guys!

I've recently ran into an issue when switching from the old discontinued `react-native-fbsdk` package to this one. Fortunately, my problem was solved with an instruction on the comments of one of the issues here ([this one](https://github.com/thebergamo/react-native-fbsdk-next/issues/96#issuecomment-922409601)), so I thought I'd add this to the readme, seemed useful!

_P.S.: I could not find any guidelines regarding PRs to this repo, so I hope this simple one is ok 😅_