### PR TITLE
feat(ios): Upgrade to Facebook iOS SDK 11.2.1

### DIFF
--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -149,13 +149,6 @@ RCT_EXPORT_METHOD(getAdvertiserID:(RCTPromiseResolveBlock)resolve
   }
 }
 
-RCT_EXPORT_METHOD(updateUserProperties:(NSDictionary *)parameters)
-{
-  parameters = RCTDictionaryWithoutNullValues(parameters);
-
-  [FBSDKAppEvents updateUserProperties:parameters handler:nil];
-}
-
 RCT_EXPORT_METHOD(setUserData:(NSDictionary *)userData)
 {
   userData = RCTDictionaryWithoutNullValues(userData);

--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -45,7 +45,7 @@ RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)optio
 
 RCT_EXPORT_METHOD(initializeSDK)
 {
-  [FBSDKApplicationDelegate initializeSDK:nil];
+  [FBSDKApplicationDelegate.sharedInstance initializeSDK];
 }
 
 RCT_EXPORT_METHOD(setAppID:(NSString *)appID)

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 9.3'
+    ss.dependency     'FBSDKCoreKit', '~> 11.2.1'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 9.3'
+    ss.dependency     'FBSDKLoginKit', '~> 11.2.1'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 9.3'
+    ss.dependency     'FBSDKShareKit', '~> 11.2.1'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end

--- a/src/FBAppEventsLogger.js
+++ b/src/FBAppEventsLogger.js
@@ -340,6 +340,9 @@ module.exports = {
    * setUserID. You must call setUserID before making this call.
    */
   updateUserProperties(parameters: Params) {
+    if (Platform.OS === 'ios') {
+      return;
+    }
     AppEventsLogger.updateUserProperties(parameters);
   },
 


### PR DESCRIPTION
This PR upgrades [Facebook SDK for iOS](https://github.com/facebook/facebook-ios-sdk) to 11.2.1.
Method `updateUserProperties` of the `RCTFBSDKAppEvents` class was removed in release 11.0.0 ([changelog](https://github.com/facebook/facebook-ios-sdk/blob/main/CHANGELOG.md#1100)).

Test Plan:

My app mostly logs events so I tested that it compiles, launches and events are visible in the "Test Events" tab in the Facebook Events Manager.