### PR TITLE
test(ci): use ccache / pod cache to accelerate iOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,15 +104,20 @@ jobs:
           key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-v1
+      - uses: actions/cache@v2
+        name: Cache Pods
+        id: pods-cache
+        with:
+          path: RNFBSDKExample/ios/Pods
+          key: ${{ runner.os }}-pods-v1-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: ${{ runner.os }}-pods-v1
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           retry_wait_seconds: 30
           max_attempts: 3
-          command: yarn install && cd RNFBSDKExample && yarn
-      - name: Install pods
-        run: cd RNFBSDKExample/ios && rm -f Podfile.lock && pod install
+          command: yarn && yarn example:install
       - name: Build ios example app
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -123,4 +128,4 @@ jobs:
           export SKIP_BUNDLING=1
           export RCT_NO_LAUNCH_PACKAGER=1
           set -o pipefail
-          yarn example:install && yarn example:devcopy && yarn example:install && cd RNFBSDKExample/ios && xcodebuild -scheme RNFBSDKExample -workspace RNFBSDKExample.xcworkspace VALID_ARCHS=\"`uname -m`\" ONLY_ACTIVE_ARCH=YES -sdk iphonesimulator -configuration Debug
+          yarn example:devcopy && yarn example:install && cd RNFBSDKExample/ios && xcodebuild -scheme RNFBSDKExample -workspace RNFBSDKExample.xcworkspace VALID_ARCHS=\"`uname -m`\" ONLY_ACTIVE_ARCH=YES -sdk iphonesimulator -configuration Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,11 @@ jobs:
           retry_wait_seconds: 30
           max_attempts: 3
           command: npm install -g yarn
+      - uses: hendrikmuhs/ccache-action@v1
+        name: Xcode Compile Cache
+        with:
+          key: ${{ runner.os }}-v1 # makes a unique key w/related restore key internally
+          max-size: 400M
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -109,4 +114,13 @@ jobs:
       - name: Install pods
         run: cd RNFBSDKExample/ios && rm -f Podfile.lock && pod install
       - name: Build ios example app
-        run: yarn example:install && yarn example:devcopy && yarn example:install && cd RNFBSDKExample/ios && xcodebuild -scheme RNFBSDKExample -workspace RNFBSDKExample.xcworkspace VALID_ARCHS=\"`uname -m`\" ONLY_ACTIVE_ARCH=YES -sdk iphonesimulator -configuration Debug
+        run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
+          export CCACHE_FILECLONE=true
+          export CCACHE_DEPEND=true
+          export CCACHE_INODECACHE=true
+          export SKIP_BUNDLING=1
+          export RCT_NO_LAUNCH_PACKAGER=1
+          set -o pipefail
+          yarn example:install && yarn example:devcopy && yarn example:install && cd RNFBSDKExample/ios && xcodebuild -scheme RNFBSDKExample -workspace RNFBSDKExample.xcworkspace VALID_ARCHS=\"`uname -m`\" ONLY_ACTIVE_ARCH=YES -sdk iphonesimulator -configuration Debug


### PR DESCRIPTION

This is a test-only change intended to accelerate the CI time to completion for the iOS build

I grabbed it from react-native-firebase where it is used and has been quite effective for us for a long time, should help here in combination with this part of the example script Podfile edits, which are in place to allow compiler caches to work:

https://github.com/thebergamo/react-native-fbsdk-next/blob/63a6230e2f7f7b1544ab748f29a0aa09441bf43b/refresh-example.sh#L49-L53

https://github.com/thebergamo/react-native-fbsdk-next/blob/63a6230e2f7f7b1544ab748f29a0aa09441bf43b/RNFBSDKExample/ios/Podfile#L29-L36