### PR TITLE
feat(ios)!: upgrade facebook-ios-sdk to v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use this library you need to ensure you match up with the correct version of 
 | <= 8.0.1  | `react-native-fbsdk` `<= 0.10`        | `<= 0.59.x`                   |
 
 > ⚠️ * Attention
-> 
+>
 > Please notice that this module in versions after 4.2.0 only supports React Native versions above 0.63.3 as it's the oldest version of React Native which support latest XCode version. Technically, it may work on older versions (test it to be sure) but **they are not supported**. Changes that accidentally break older react-native versions may be issued without regard to semantic versioning constraints because we do not test against the older versions. Please see [this issue](https://github.com/thebergamo/react-native-fbsdk-next/issues/30) for an example of a previous break. Please update to current react-native versions.
 
 ### 1. Install the library
@@ -59,7 +59,7 @@ $ cd ios/ && pod install
 
 - **React Native <= 0.59**
 
-> For support with React Native <= 0.59, please refer to [React Native FBSDK](https://github.com/facebook/react-native-fbsdk) 
+> For support with React Native <= 0.59, please refer to [React Native FBSDK](https://github.com/facebook/react-native-fbsdk)
 
 If you can't or don't want to use the CLI tool, you can also manually link the library using the instructions below (click on the arrow to show them):
 
@@ -188,7 +188,7 @@ Undefined symbols for architecture x86_64:
 
    Either:
 
-- add a new file named `File.Swift` in the main project folder and answer "yes" when Xcode asks you if you want to "Create Bridging Header" 
+- add a new file named `File.Swift` in the main project folder and answer "yes" when Xcode asks you if you want to "Create Bridging Header"
 The empty swift file makes this change to the Header Search Path on your build settings:
 ```
 $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)
@@ -208,14 +208,14 @@ $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)
    ```
 
   Both result in fixing search paths.
-   
+
 5. AppLink.fetchDeferredAppLink does not work (on iOS at least)
-   
+
    Both the Facebook App and your app have to have App Tracking Transparency (ATT) permission granted for facebook deferred app links to work. See [this related issue](https://github.com/thebergamo/react-native-fbsdk-next/issues/104#issuecomment-931488609)
-  
+
 6. You get an exception `App ID not found. Add a string value with your app ID for the key FacebookAppID to the Info.plist or call [FBSDKSettings setAppID:].`
 
-  If you find yourself in this situation, and you are certain that you have the FacebookAppID in your Info.plist or that you have called `setAppId`, you *may* be able to fix it by adding the following lines to `AppDelegate.m` inside the `- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions`, just before the `return YES` statement: 
+  If you find yourself in this situation, and you are certain that you have the FacebookAppID in your Info.plist or that you have called `setAppId`, you *may* be able to fix it by adding the following lines to `AppDelegate.m` inside the `- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions`, just before the `return YES` statement:
 
   ```
     [[FBSDKApplicationDelegate sharedInstance] application:application
@@ -631,15 +631,23 @@ new GraphRequestManager().addRequest(infoRequest).start();
 ```
 
 ## Example app
+To run the example app, you'll first need to setup the environment:
+```
+refresh-example.sh
+```
+This will create a new app in the `RNFBSDKExample` directory, using the latest version of React Native.
+Next, it will patch the necessary files so you may run the example app.
 
-### iOS
+```
+yarn example:ios
+```
+or
+```
+yarn example:android
+```
 
-- Run `pod install` in `example/ios`
-- Run `yarn example:ios`
+Note: You'll probably want to change the Facebook App ID to your own, else the example app won't be able to login.  To change it, edit your local copy of `refresh-example.sh`, update the `FacebookAppId` variable, then re-run `refresh-example.sh` to regenerate the example directory.
 
-### Android
-
-- Run `yarn example:android`
 
 ## Join the React Native community
 

--- a/RNFBSDKExample/ios/Podfile.lock
+++ b/RNFBSDKExample/ios/Podfile.lock
@@ -2,10 +2,8 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBAEMKit (11.2.1):
-    - FBAEMKit/AEM (= 11.2.1)
-  - FBAEMKit/AEM (11.2.1):
-    - FBSDKCoreKit_Basics (~> 11.2.1)
+  - FBAEMKit (12.1.0):
+    - FBSDKCoreKit_Basics (= 12.1.0)
   - FBLazyVector (0.66.3)
   - FBReactNativeSpec (0.66.3):
     - RCT-Folly (= 2021.06.28.00-v2)
@@ -14,24 +12,14 @@ PODS:
     - React-Core (= 0.66.3)
     - React-jsi (= 0.66.3)
     - ReactCommon/turbomodule/core (= 0.66.3)
-  - FBSDKCoreKit (11.2.1):
-    - FBSDKCoreKit/Core (= 11.2.1)
-  - FBSDKCoreKit/Core (11.2.1):
-    - FBAEMKit (~> 11.2.1)
-    - FBSDKCoreKit_Basics (~> 11.2.1)
-  - FBSDKCoreKit_Basics (11.2.1):
-    - FBSDKCoreKit_Basics/Basics (= 11.2.1)
-  - FBSDKCoreKit_Basics/Basics (11.2.1)
-  - FBSDKLoginKit (11.2.1):
-    - FBSDKLoginKit/Login (= 11.2.1)
-  - FBSDKLoginKit/Login (11.2.1):
-    - FBSDKCoreKit (~> 11.2.1)
-    - FBSDKCoreKit_Basics (~> 11.2.1)
-  - FBSDKShareKit (11.2.1):
-    - FBSDKShareKit/Share (= 11.2.1)
-  - FBSDKShareKit/Share (11.2.1):
-    - FBSDKCoreKit (~> 11.2.1)
-    - FBSDKCoreKit_Basics (~> 11.2.1)
+  - FBSDKCoreKit (12.1.0):
+    - FBAEMKit (= 12.1.0)
+    - FBSDKCoreKit_Basics (= 12.1.0)
+  - FBSDKCoreKit_Basics (12.1.0)
+  - FBSDKLoginKit (12.1.0):
+    - FBSDKCoreKit (= 12.1.0)
+  - FBSDKShareKit (12.1.0):
+    - FBSDKCoreKit (= 12.1.0)
   - Flipper (0.99.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -300,13 +288,13 @@ PODS:
     - react-native-fbsdk-next/Login (= 4.6.0)
     - react-native-fbsdk-next/Share (= 4.6.0)
   - react-native-fbsdk-next/Core (4.6.0):
-    - FBSDKCoreKit (~> 11.2.1)
+    - FBSDKCoreKit (~> 12.1.0)
     - React-Core
   - react-native-fbsdk-next/Login (4.6.0):
-    - FBSDKLoginKit (~> 11.2.1)
+    - FBSDKLoginKit (~> 12.1.0)
     - React-Core
   - react-native-fbsdk-next/Share (4.6.0):
-    - FBSDKShareKit (~> 11.2.1)
+    - FBSDKShareKit (~> 12.1.0)
     - React-Core
   - React-perflogger (0.66.3)
   - React-RCTActionSheet (0.66.3):
@@ -523,13 +511,13 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBAEMKit: 5de0a7aaa854eec69bb5be20795952a63d38a5f6
+  FBAEMKit: 56c0bb9b42e3747cd82b67934f0c2b19325382ea
   FBLazyVector: de148e8310b8b878db304ceea2fec13f2c02e3a0
   FBReactNativeSpec: 6192956c9e346013d5f1809ba049af720b11c6a4
-  FBSDKCoreKit: bf655f808b040ed66a72b9922911b39d703e64f4
-  FBSDKCoreKit_Basics: 73ebe3a27eb688ac5b5aa7e99f68992993042115
-  FBSDKLoginKit: 2e76831ef08d356b8f9150ea51cce865074ea304
-  FBSDKShareKit: 1c8c3000880382ae005fe4a4e7eae9932db1a837
+  FBSDKCoreKit: 75368765d9c2303073145a7925dfaa9d60bcd77b
+  FBSDKCoreKit_Basics: 39865aff97e5f6951a78fb3e89dc4460e35e1895
+  FBSDKLoginKit: e993f97c7cc794c5da4056d8aec3c3d66033a727
+  FBSDKShareKit: 24943f539dbe382a6fad04952ea1aee29b100c1f
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -555,7 +543,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 433a691aee158533a6a6ee9c86cb4a1684fa2853
   React-jsinspector: d9c8eb0b53f0da206fed56612b289fec84991157
   React-logger: e522e76fa3e9ec3e7d7115b49485cc065cf4ae06
-  react-native-fbsdk-next: b1572d5e2b9f6d9d362e0ed3fbb444a714db405b
+  react-native-fbsdk-next: 81dc96abbc75057c70dfd0880de5f50b432719f4
   React-perflogger: 73732888d37d4f5065198727b167846743232882
   React-RCTActionSheet: 96c6d774fa89b1f7c59fc460adc3245ba2d7fd79
   React-RCTAnimation: 8940cfd3a8640bd6f6372150dbdb83a79bcbae6c

--- a/RNFBSDKExample/ios/RNFBSDKExample.xcodeproj/project.pbxproj
+++ b/RNFBSDKExample/ios/RNFBSDKExample.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		49817B9083BBFACB0AE839AE /* libPods-RNFBSDKExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A93B4331728048FE6397EBEE /* libPods-RNFBSDKExample.a */; };
-		4A274766B7244672EA8E3B46 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 57710065B75553339F9E186B /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */; };
+		5E7651EFD4B27D699CFA56AB /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 798E57CD14852CBFEA9D8479 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */; };
+		76000F148C6E3DEEF71D0FC3 /* libPods-RNFBSDKExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 47A45FE6910B8D1A2BA5E6A4 /* libPods-RNFBSDKExample.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -36,13 +36,13 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = RNFBSDKExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNFBSDKExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = RNFBSDKExample/main.m; sourceTree = "<group>"; };
-		57710065B75553339F9E186B /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample-RNFBSDKExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6D330178BE3A60F4975C46BE /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		75224351537604FB3258A212 /* Pods-RNFBSDKExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.debug.xcconfig"; sourceTree = "<group>"; };
+		307F05EC8DA4A8CAB25C13A6 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3D43DFCE89624627557CAA87 /* Pods-RNFBSDKExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.debug.xcconfig"; sourceTree = "<group>"; };
+		47A45FE6910B8D1A2BA5E6A4 /* libPods-RNFBSDKExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D4798C7BC2A7668823641CB /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		798E57CD14852CBFEA9D8479 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample-RNFBSDKExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNFBSDKExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		A93B4331728048FE6397EBEE /* libPods-RNFBSDKExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CF116E57B781CEAD38167619 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		DFB2D669C09540BD2F149069 /* Pods-RNFBSDKExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.release.xcconfig"; sourceTree = "<group>"; };
+		B8B5E7E1618126DEBC883AE5 /* Pods-RNFBSDKExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -51,7 +51,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4A274766B7244672EA8E3B46 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */,
+				5E7651EFD4B27D699CFA56AB /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				49817B9083BBFACB0AE839AE /* libPods-RNFBSDKExample.a in Frameworks */,
+				76000F148C6E3DEEF71D0FC3 /* libPods-RNFBSDKExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,10 +100,22 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				A93B4331728048FE6397EBEE /* libPods-RNFBSDKExample.a */,
-				57710065B75553339F9E186B /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */,
+				47A45FE6910B8D1A2BA5E6A4 /* libPods-RNFBSDKExample.a */,
+				798E57CD14852CBFEA9D8479 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4DA6CA50D8C309A8AA3334CC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				3D43DFCE89624627557CAA87 /* Pods-RNFBSDKExample.debug.xcconfig */,
+				B8B5E7E1618126DEBC883AE5 /* Pods-RNFBSDKExample.release.xcconfig */,
+				307F05EC8DA4A8CAB25C13A6 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */,
+				6D4798C7BC2A7668823641CB /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -121,7 +133,7 @@
 				00E356EF1AD99517003FC87E /* RNFBSDKExampleTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				BC6AA8500F2151BF035F1BEF /* Pods */,
+				4DA6CA50D8C309A8AA3334CC /* Pods */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -137,18 +149,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		BC6AA8500F2151BF035F1BEF /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				75224351537604FB3258A212 /* Pods-RNFBSDKExample.debug.xcconfig */,
-				DFB2D669C09540BD2F149069 /* Pods-RNFBSDKExample.release.xcconfig */,
-				CF116E57B781CEAD38167619 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */,
-				6D330178BE3A60F4975C46BE /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -156,12 +156,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "RNFBSDKExampleTests" */;
 			buildPhases = (
-				6B6EDF3E772EA1FA4EE604F9 /* [CP] Check Pods Manifest.lock */,
+				58C9213B7F1EBC73B6C772DC /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				E821266CB5A4BDBB61B50024 /* [CP] Embed Pods Frameworks */,
-				1D68D6A0D5660A222CF019AD /* [CP] Copy Pods Resources */,
+				934F75B7EC62836A861C351E /* [CP] Embed Pods Frameworks */,
+				062C5006D9AD7B426F08595B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -177,14 +177,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "RNFBSDKExample" */;
 			buildPhases = (
-				7D1E127067AD36CFDC8CFED2 /* [CP] Check Pods Manifest.lock */,
+				884E9B7BA348BDA8A15B51BE /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				975D3220BF68525DA7EFAAAF /* [CP] Embed Pods Frameworks */,
-				6EE0990F8E4DD2BB00041823 /* [CP] Copy Pods Resources */,
+				8DF35C47C90BAD0DE95CBB96 /* [CP] Embed Pods Frameworks */,
+				E182BEB54E4060E53CC0C6BF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -265,7 +265,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nexport NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		1D68D6A0D5660A222CF019AD /* [CP] Copy Pods Resources */ = {
+		062C5006D9AD7B426F08595B /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -282,7 +282,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6B6EDF3E772EA1FA4EE604F9 /* [CP] Check Pods Manifest.lock */ = {
+		58C9213B7F1EBC73B6C772DC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -304,24 +304,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6EE0990F8E4DD2BB00041823 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7D1E127067AD36CFDC8CFED2 /* [CP] Check Pods Manifest.lock */ = {
+		884E9B7BA348BDA8A15B51BE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -343,7 +326,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		975D3220BF68525DA7EFAAAF /* [CP] Embed Pods Frameworks */ = {
+		8DF35C47C90BAD0DE95CBB96 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -360,7 +343,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E821266CB5A4BDBB61B50024 /* [CP] Embed Pods Frameworks */ = {
+		934F75B7EC62836A861C351E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -375,6 +358,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E182BEB54E4060E53CC0C6BF /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -429,7 +429,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CF116E57B781CEAD38167619 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */;
+			baseConfigurationReference = 307F05EC8DA4A8CAB25C13A6 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				EXCLUDED_ARCHS = i386;
@@ -458,7 +458,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6D330178BE3A60F4975C46BE /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */;
+			baseConfigurationReference = 6D4798C7BC2A7668823641CB /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -484,7 +484,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75224351537604FB3258A212 /* Pods-RNFBSDKExample.debug.xcconfig */;
+			baseConfigurationReference = 3D43DFCE89624627557CAA87 /* Pods-RNFBSDKExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -512,7 +512,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFB2D669C09540BD2F149069 /* Pods-RNFBSDKExample.release.xcconfig */;
+			baseConfigurationReference = B8B5E7E1618126DEBC883AE5 /* Pods-RNFBSDKExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/ios/RCTFBSDK/core/RCTFBSDKAccessToken.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAccessToken.m
@@ -51,7 +51,7 @@ RCT_EXPORT_METHOD(setCurrentAccessToken:(FBSDKAccessToken *)token)
 
 RCT_EXPORT_METHOD(refreshCurrentAccessTokenAsync:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  [FBSDKAccessToken refreshCurrentAccessToken:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
+  [FBSDKAccessToken refreshCurrentAccessTokenWithCompletion:^(id<FBSDKGraphRequestConnecting> connection, id result, NSError *error) {
     if (error) {
       reject(@"FacebookSDK", error.localizedDescription, error);
     } else {

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -21,7 +21,6 @@
 #import <React/RCTUtils.h>
 
 #import "RCTConvert+FBSDKAccessToken.h"
-#import <FBSDKCoreKit/FBSDKAppEventsUtility.h>
 
 @implementation RCTConvert (RCTFBSDKAppEvents)
 
@@ -141,8 +140,8 @@ RCT_EXPORT_METHOD(getAdvertiserID:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
   @try {
-    NSString *advertiserID = [[FBSDKAppEventsUtility shared] advertiserID];
-    resolve(advertiserID);
+    // advertiserID is no longer available to iOS from FBSDK v12
+    resolve(nil);
   }
   @catch (NSError *error) {
     reject(@"E_ADVERTISER_ID_ERROR", @"Can not get advertiserID", error);

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -152,16 +152,16 @@ RCT_EXPORT_METHOD(setUserData:(NSDictionary *)userData)
 {
   userData = RCTDictionaryWithoutNullValues(userData);
 
-  [FBSDKAppEvents setUserEmail:userData[@"email"]
-                     firstName:userData[@"firstName"]
-                      lastName:userData[@"lastName"]
-                         phone:userData[@"phone"]
-                   dateOfBirth:userData[@"dateOfBirth"]
-                        gender:userData[@"gender"]
-                          city:userData[@"city"]
-                         state:userData[@"state"]
-                           zip:userData[@"zip"]
-                       country:userData[@"country"]];
+  [FBSDKAppEvents.shared setUserEmail:userData[@"email"]
+                            firstName:userData[@"firstName"]
+                             lastName:userData[@"lastName"]
+                                phone:userData[@"phone"]
+                          dateOfBirth:userData[@"dateOfBirth"]
+                               gender:userData[@"gender"]
+                                 city:userData[@"city"]
+                                state:userData[@"state"]
+                                  zip:userData[@"zip"]
+                              country:userData[@"country"]];
 }
 
 RCT_EXPORT_METHOD(setFlushBehavior:(FBSDKAppEventsFlushBehavior)flushBehavior)

--- a/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m
@@ -93,11 +93,11 @@ static NSArray<FBSDKGraphRequest *> *FBSDKGraphRequestArray(id json)
   g_pendingConnection = [[NSMutableArray alloc] init];
   [g_pendingConnection addObject:self];
   for (int i = 0; i < _requestBatch.count; i++) {
-    FBSDKGraphRequestBlock completionHandler = ^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
+    FBSDKGraphRequestCompletion completion = ^(id<FBSDKGraphRequestConnecting> connection, id result, NSError *error) {
       NSDictionary *errorDict = error ? RCTJSErrorFromNSError(error) : nil;
       _response[[NSString stringWithFormat: @"%i", i]] = @[RCTNullIfNil(errorDict), RCTNullIfNil(result)];
     };
-    [_connection addRequest:_requestBatch[i] completionHandler:completionHandler];
+    [_connection addRequest:_requestBatch[i] completion:completion];
   }
   [_connection start];
 }

--- a/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m
@@ -95,7 +95,7 @@ static NSArray<FBSDKGraphRequest *> *FBSDKGraphRequestArray(id json)
   for (int i = 0; i < _requestBatch.count; i++) {
     FBSDKGraphRequestCompletion completion = ^(id<FBSDKGraphRequestConnecting> connection, id result, NSError *error) {
       NSDictionary *errorDict = error ? RCTJSErrorFromNSError(error) : nil;
-      _response[[NSString stringWithFormat: @"%i", i]] = @[RCTNullIfNil(errorDict), RCTNullIfNil(result)];
+      self->_response[[NSString stringWithFormat: @"%i", i]] = @[RCTNullIfNil(errorDict), RCTNullIfNil(result)];
     };
     [_connection addRequest:_requestBatch[i] completion:completion];
   }

--- a/ios/RCTFBSDK/core/RCTFBSDKGraphRequestManager.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKGraphRequestManager.m
@@ -34,9 +34,9 @@ RCT_REMAP_METHOD(start, startWithBatch:(NSArray *)requestBatch
                          batchCallback:(RCTResponseSenderBlock)callback)
 {
   RCTFBSDKGraphRequestConnectionContainer *connection =
-  [[RCTFBSDKGraphRequestConnectionContainer alloc] initWithRequestBatch:requestBatch
-                                                                timeout:timeout
-                                                          batchCallback:callback];
+    [[RCTFBSDKGraphRequestConnectionContainer alloc] initWithRequestBatch:requestBatch
+                                                                  timeout:[timeout integerValue]
+                                                            batchCallback:callback];
   [connection start];
 }
 

--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -23,24 +23,24 @@ RCT_EXPORT_MODULE(FBSettings);
 
 RCT_EXPORT_METHOD(getAdvertiserTrackingEnabled:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-  BOOL ATE = [FBSDKSettings isAdvertiserTrackingEnabled];
+  BOOL ATE = FBSDKSettings.sharedSettings.isAdvertiserTrackingEnabled;
   resolve(@(ATE));
 }
 
 RCT_EXPORT_METHOD(setAdvertiserTrackingEnabled:(BOOL)ATE resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-  BOOL result = [FBSDKSettings setAdvertiserTrackingEnabled:ATE];
-  resolve(@(result));
+  FBSDKSettings.sharedSettings.advertiserTrackingEnabled = ATE;
+  resolve(@(true)); // true means successfully changed
 }
 
 RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options)
 {
-  [FBSDKSettings setDataProcessingOptions:options];
+  [FBSDKSettings.sharedSettings setDataProcessingOptions:options];
 }
 
 RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options country:(int)country state:(int)state)
 {
-  [FBSDKSettings setDataProcessingOptions:options country:country state:state];
+  [FBSDKSettings.sharedSettings setDataProcessingOptions:options country:country state:state];
 }
 
 RCT_EXPORT_METHOD(initializeSDK)
@@ -50,7 +50,7 @@ RCT_EXPORT_METHOD(initializeSDK)
 
 RCT_EXPORT_METHOD(setAppID:(NSString *)appID)
 {
-  [FBSDKSettings setAppID:appID];
+  [FBSDKSettings.sharedSettings setAppID:appID];
 }
 
 @end

--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -47,8 +47,7 @@ RCT_EXPORT_MODULE(FBShareDialog);
 - (instancetype)init
 {
   if (self = [super init]) {
-    _shareDialog = [[FBSDKShareDialog alloc] init];
-    _shareDialog.delegate = self;
+    _shareDialog = [[FBSDKShareDialog alloc] initWithViewController:nil content:nil delegate:self];
   }
   return self;
 }

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -10,21 +10,21 @@ Pod::Spec.new do |s|
   s.license       = package['license']
   s.homepage      = package['homepage']
   s.source        = { :git => 'https://github.com/thebergamo/react-native-fbsdk-next.git', :tag => "v#{package['version']}" }
-  s.platforms     = { :ios => "9.0", :tvos => "9.2" }
+  s.platforms     = { :ios => "10.0", :tvos => "10.0" }
   s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 11.2.1'
+    ss.dependency     'FBSDKCoreKit', '~> 12.1.0'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 11.2.1'
+    ss.dependency     'FBSDKLoginKit', '~> 12.1.0'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 11.2.1'
+    ss.dependency     'FBSDKShareKit', '~> 12.1.0'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -61,11 +61,12 @@ rm -f ios/Podfile??
 # Adding the facebook App Id, App Name, are minimum steps
 
 # note the app id used here does not work fully - replace with your own - but it *does* initialize and prove things to a point.
-sed -i -e 's/<\/resources>/    <string name="facebook_app_id">1523458767976650<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
+FacebookAppId=1523458767976650
+sed -i -e 's/<\/resources>/    <string name="facebook_app_id">${FacebookAppId}<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
 rm -f android/app/src/main/res/values/strings.xml??
 sed -i -e 's/^<\/dict>/  <key>FacebookDisplayName<\/key>\n  <string>RNFBSDKExample<\/string>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
-sed -i -e 's/^<\/dict>/  <key>FacebookAppID<\/key>\n  <string>1523458767976650<\/string>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
+sed -i -e 's/^<\/dict>/  <key>FacebookAppID<\/key>\n  <string>${FacebookAppId}<\/string>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
 sed -i -e 's/<\/application>/  <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string\/facebook_app_id"\/>\n    <\/application>/' android/app/src/main/AndroidManifest.xml
 rm -f android/app/src/main/AndroidManifest.xml??
@@ -73,7 +74,7 @@ sed -i -e 's/<\/application>/  <meta-data android:name="com.facebook.sdk.Applica
 rm -f android/app/src/main/AndroidManifest.xml??
 
 # You may optionally want to handle facebook app links
-sed -i -e 's/<\/resources>/    <string name="fb_auto_applink_scheme">fb1523458767976650<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
+sed -i -e 's/<\/resources>/    <string name="fb_auto_applink_scheme">fb${FacebookAppId}<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
 rm -f android/app/src/main/res/values/strings.xml??
 sed -i -e 's/<\/intent-filter>/<\/intent-filter>\n        <intent-filter>\n            <action android:name="android.intent.action.VIEW" \/>\n            <category android:name="android.intent.category.DEFAULT" \/>\n            <category android:name="android.intent.category.BROWSABLE" \/>\n            <data android:host="applinks" android:scheme="@string\/fb_auto_applink_scheme" \/>\n        <\/intent-filter>/' android/app/src/main/AndroidManifest.xml
 rm -f android/app/src/main/AndroidManifest.xml??
@@ -91,7 +92,7 @@ sed -i -e 's/<\/activity>/<\/activity>\n      <activity android:name="com.facebo
 rm -f android/app/src/main/AndroidManifest.xml??
 
 # This is required for login to work on android and is listed as a requirement for the iOS SDK
-sed -i -e 's/<\/resources>/    <string name="fb_login_protocol_scheme">1523458767976650<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
+sed -i -e 's/<\/resources>/    <string name="fb_login_protocol_scheme">${FacebookAppId}<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
 rm -f android/app/src/main/res/values/strings.xml??
 
 sed -i -e 's/^<\/dict>/  <key>LSApplicationQueriesSchemes<\/key>\n  <array>\n    <string>fb-messenger-share-api<\/string>\n    <string>fbauth2<\/string>\n    <string>fbapi<\/string>\n  <\/array>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
@@ -112,7 +113,7 @@ sed -i -e 's/<\/manifest>/    <queries>\n      <provider android:authorities="co
 rm -f android/app/src/main/AndroidManifest.xml??
 sed -i -e 's/<string>fbapi<\/string>/<string>fbapi<\/string>\n    <string>fb-messenger-share-api<\/string>\n    <string>fbauth2<\/string>\n    <string>fbapi<\/string>\n    <string>fbapi20130214<\/string>\n    <string>fbapi20130410<\/string>\n    <string>fbapi20130702<\/string>\n    <string>fbapi20131010<\/string>\n    <string>fbapi20131219<\/string>\n    <string>fbapi20140410<\/string>\n    <string>fbapi20140116<\/string>\n    <string>fbapi20150313<\/string>\n    <string>fbapi20150629<\/string>\n    <string>fbapi20160328<\/string>\n    <string>fbauth<\/string>\n    <string>fbshareextension<\/string>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
-sed -i -e 's/^<\/dict>/  <key>CFBundleURLTypes<\/key>\n  <array>\n    <dict>\n     <key>CFBundleURLSchemes<\/key>\n     <array>\n       <string>fb1523458767976650<\/string>\n     <\/array>\n   <\/dict>\n  <\/array>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
+sed -i -e 's/^<\/dict>/  <key>CFBundleURLTypes<\/key>\n  <array>\n    <dict>\n     <key>CFBundleURLSchemes<\/key>\n     <array>\n       <string>fb${FacebookAppId}<\/string>\n     <\/array>\n   <\/dict>\n  <\/array>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
 
 # You may want to integrate Facebook's content provider

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -62,11 +62,11 @@ rm -f ios/Podfile??
 
 # note the app id used here does not work fully - replace with your own - but it *does* initialize and prove things to a point.
 FacebookAppId=1523458767976650
-sed -i -e 's/<\/resources>/    <string name="facebook_app_id">${FacebookAppId}<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
+sed -i -e 's/<\/resources>/    <string name="facebook_app_id">'${FacebookAppId}'<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
 rm -f android/app/src/main/res/values/strings.xml??
 sed -i -e 's/^<\/dict>/  <key>FacebookDisplayName<\/key>\n  <string>RNFBSDKExample<\/string>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
-sed -i -e 's/^<\/dict>/  <key>FacebookAppID<\/key>\n  <string>${FacebookAppId}<\/string>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
+sed -i -e 's/^<\/dict>/  <key>FacebookAppID<\/key>\n  <string>'${FacebookAppId}'<\/string>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
 sed -i -e 's/<\/application>/  <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string\/facebook_app_id"\/>\n    <\/application>/' android/app/src/main/AndroidManifest.xml
 rm -f android/app/src/main/AndroidManifest.xml??
@@ -74,7 +74,7 @@ sed -i -e 's/<\/application>/  <meta-data android:name="com.facebook.sdk.Applica
 rm -f android/app/src/main/AndroidManifest.xml??
 
 # You may optionally want to handle facebook app links
-sed -i -e 's/<\/resources>/    <string name="fb_auto_applink_scheme">fb${FacebookAppId}<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
+sed -i -e 's/<\/resources>/    <string name="fb_auto_applink_scheme">fb'${FacebookAppId}'<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
 rm -f android/app/src/main/res/values/strings.xml??
 sed -i -e 's/<\/intent-filter>/<\/intent-filter>\n        <intent-filter>\n            <action android:name="android.intent.action.VIEW" \/>\n            <category android:name="android.intent.category.DEFAULT" \/>\n            <category android:name="android.intent.category.BROWSABLE" \/>\n            <data android:host="applinks" android:scheme="@string\/fb_auto_applink_scheme" \/>\n        <\/intent-filter>/' android/app/src/main/AndroidManifest.xml
 rm -f android/app/src/main/AndroidManifest.xml??
@@ -92,7 +92,7 @@ sed -i -e 's/<\/activity>/<\/activity>\n      <activity android:name="com.facebo
 rm -f android/app/src/main/AndroidManifest.xml??
 
 # This is required for login to work on android and is listed as a requirement for the iOS SDK
-sed -i -e 's/<\/resources>/    <string name="fb_login_protocol_scheme">${FacebookAppId}<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
+sed -i -e 's/<\/resources>/    <string name="fb_login_protocol_scheme">'${FacebookAppId}'<\/string>\n<\/resources>/' android/app/src/main/res/values/strings.xml
 rm -f android/app/src/main/res/values/strings.xml??
 
 sed -i -e 's/^<\/dict>/  <key>LSApplicationQueriesSchemes<\/key>\n  <array>\n    <string>fb-messenger-share-api<\/string>\n    <string>fbauth2<\/string>\n    <string>fbapi<\/string>\n  <\/array>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
@@ -113,7 +113,7 @@ sed -i -e 's/<\/manifest>/    <queries>\n      <provider android:authorities="co
 rm -f android/app/src/main/AndroidManifest.xml??
 sed -i -e 's/<string>fbapi<\/string>/<string>fbapi<\/string>\n    <string>fb-messenger-share-api<\/string>\n    <string>fbauth2<\/string>\n    <string>fbapi<\/string>\n    <string>fbapi20130214<\/string>\n    <string>fbapi20130410<\/string>\n    <string>fbapi20130702<\/string>\n    <string>fbapi20131010<\/string>\n    <string>fbapi20131219<\/string>\n    <string>fbapi20140410<\/string>\n    <string>fbapi20140116<\/string>\n    <string>fbapi20150313<\/string>\n    <string>fbapi20150629<\/string>\n    <string>fbapi20160328<\/string>\n    <string>fbauth<\/string>\n    <string>fbshareextension<\/string>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
-sed -i -e 's/^<\/dict>/  <key>CFBundleURLTypes<\/key>\n  <array>\n    <dict>\n     <key>CFBundleURLSchemes<\/key>\n     <array>\n       <string>fb${FacebookAppId}<\/string>\n     <\/array>\n   <\/dict>\n  <\/array>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
+sed -i -e 's/^<\/dict>/  <key>CFBundleURLTypes<\/key>\n  <array>\n    <dict>\n     <key>CFBundleURLSchemes<\/key>\n     <array>\n       <string>fb'${FacebookAppId}'<\/string>\n     <\/array>\n   <\/dict>\n  <\/array>\n<\/dict>/' ios/RNFBSDKExample/Info.plist
 rm -f ios/RNFBSDKExample/Info.plist??
 
 # You may want to integrate Facebook's content provider


### PR DESCRIPTION
Upgrade FBSDK to v12.1.0.  This fixes #55.

**BREAKING CHANGE:**
* For iOS, `getAdvertiserID` will always return null, as the upstream FBSDK no longer provides the advertiserID
* iOS minimum deployment target changes from 9 to 10, due to upstream FBSDK change
* `setAdvertiserTrackingEnabled` always returns `true` now, as it will never fail; no function change from previous implementation

Here is a summary of the changes:
* Updated `react-native-fbsdk-next.podspec` to specify FBSCK v12.1.0
* Fixed compiler warnings and deprecations for iOS builds
* Updated README to add additional instructions for running the example
* Updated `refresh-example.sh` to extract the Facebook App ID into a variable
* Updated example folder artifacts based on latest changes

I tested these changes by running the example and substituting my own local Facebook App ID and verified I could log in and log out with the test app.

Note: My editor trimmed some whitespace from the ends of a few lines in the `README.md` file, so the changes look larger than they actually are.  All the content changes I made are near the end of the file.
