### PR TITLE
docs(README, v5): update ios native initialization to match new style

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ If you would like to initialize the Facebook SDK even earlier in startup for iOS
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  [FBSDKApplicationDelegate initializeSDK:launchOptions]; // <- add this
+  [FBSDKApplicationDelegate.sharedInstance initializeSDK]; // <- add this
 
   // your other stuff
 }


### PR DESCRIPTION

The iOS native initialization style has changed with the update to facebook-ios-sdk v11 contained in v5 here, and it the docs are out of date

How to do it now https://github.com/thebergamo/react-native-fbsdk-next/pull/125/files#diff-be03dd17b2019e2f4ddd389c2a9dbfceaf560485d2111c8462bc0c8530695878

> [FBSDKApplicationDelegate.sharedInstance initializeSDK];

I will also update the release notes

Fixes #131 