### PR TITLE
fix: adjust import and jest eslint env

### DIFF
--- a/jest/mocks/index.js
+++ b/jest/mocks/index.js
@@ -1,4 +1,5 @@
-const nonMocked = require('../../lib/commonjs');
+/* eslint-env jest */
+const nonMocked = require('../../src');
 
 export const mockAppEvents = {
   AchievedLevel: 'fb_mobile_level_achieved',

--- a/jest/mocks/index.js
+++ b/jest/mocks/index.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
-const nonMocked = require('../../src');
+const LoginButton = require('../../lib/commonjs/FBLoginButton');
+
 
 export const mockAppEvents = {
   AchievedLevel: 'fb_mobile_level_achieved',
@@ -60,5 +61,5 @@ export default {
   Settings: {
     initializeSDK: jest.fn(),
   },
-  LoginButton: nonMocked.LoginButton,
+  LoginButton,
 };


### PR DESCRIPTION
Hello! After this [merge](https://github.com/thebergamo/react-native-fbsdk-next/pull/140) I tried to update the lib and use the mocks but I'm getting the following error:

![Screen Shot 2021-11-22 at 11 04 21](https://user-images.githubusercontent.com/11574033/142877220-4f3c1ba1-b0ed-4dd5-a2ea-8e97a367adfb.png)

So I change the import to the component itself like react-native-permission [does](https://github.com/zoontek/react-native-permissions/blob/master/mock.js) and started working on the app.

Also, I'm adding the `/* eslint-env jest */` to avoid eslint error on this file (didn't see this on the first PR)

