### PR TITLE
refactor: resolve warnings in RCTLoginButton and FBLoginButtonManager

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
@@ -35,7 +35,7 @@ public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
 
     public static final String REACT_CLASS = "RCTFBLoginButton";
 
-    private FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
+    private final FBActivityEventListener mActivityEventListener = new FBActivityEventListener();
 
     public FBLoginButtonManager(ReactApplicationContext reactApplicationContext) {
         reactApplicationContext.addActivityEventListener(mActivityEventListener);
@@ -49,17 +49,28 @@ public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
     @Override
     public RCTLoginButton createViewInstance(ThemedReactContext context) {
         return new RCTLoginButton(context, mActivityEventListener.getCallbackManager());
-
     }
 
     @ReactProp(name = "loginBehaviorAndroid")
     public void setLoginBehavior(RCTLoginButton loginButton, @Nullable String loginBehavior) {
-        loginButton.setLoginBehavior(LoginBehavior.valueOf(loginBehavior.toUpperCase()));
+        LoginBehavior behavior = LoginBehavior.NATIVE_WITH_FALLBACK;
+
+        if (loginBehavior != null) {
+            behavior = LoginBehavior.valueOf(loginBehavior.toUpperCase());
+        }
+
+        loginButton.setLoginBehavior(behavior);
     }
 
     @ReactProp(name = "defaultAudience")
     public void setDefaultAudience(RCTLoginButton loginButton, @Nullable String defaultAudience) {
-        loginButton.setDefaultAudience(DefaultAudience.valueOf(defaultAudience.toUpperCase()));
+        DefaultAudience audience = DefaultAudience.FRIENDS;
+
+        if (defaultAudience != null) {
+            audience = DefaultAudience.valueOf(defaultAudience.toUpperCase());
+        }
+
+        loginButton.setDefaultAudience(audience);
     }
 
     @ReactProp(name = "permissions")

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
@@ -20,8 +20,6 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import android.content.Intent;
-
 import com.facebook.AccessToken;
 import com.facebook.AccessTokenTracker;
 import com.facebook.CallbackManager;
@@ -43,7 +41,7 @@ import java.util.Set;
  */
 public class RCTLoginButton extends LoginButton {
 
-    private CallbackManager mCallbackManager;
+    private final CallbackManager mCallbackManager;
     private AccessTokenTracker mAccessTokenTracker;
 
     public RCTLoginButton(ThemedReactContext context, CallbackManager callbackManager) {

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
@@ -42,7 +42,6 @@ import java.util.Set;
 public class RCTLoginButton extends LoginButton {
 
     private final CallbackManager mCallbackManager;
-    private AccessTokenTracker mAccessTokenTracker;
 
     public RCTLoginButton(ThemedReactContext context, CallbackManager callbackManager) {
         super(context);
@@ -52,7 +51,7 @@ public class RCTLoginButton extends LoginButton {
     }
 
     public void init() {
-        mAccessTokenTracker = new AccessTokenTracker() {
+        new AccessTokenTracker() {
             @Override
             protected void onCurrentAccessTokenChanged(
                     AccessToken oldAccessToken,


### PR DESCRIPTION
Resolved some warnings in RCTLoginButton and FBLoginButtonManager

* nullable warnings
* variable should be marked as `final` warning
* variable never accessed warning

## Test Plain

1. `yarn example:install && yarn example:devcopy && yarn example:install && yarn example:android`
2. Press on the login button
3. The alert should show after the login process, it means the onChange is working properly, no matter login is successful or not, I tested `onCancel` and `onError`.