### PR TITLE
feat(ios): AEM logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,13 +633,13 @@ The DeepLink URL from the re-engagement ads should be passed to the AEM Kit even
 
 #### **Step 2. Add AEM Logging**
 
-Use the AEMReporter exported from the sdk to log event to AEM, `logAEMEvent` function will bypass if platform isn't iOS, it's safe to call without platform determined.
+Use the AEMReporterIOS exported from the sdk to log event to AEM, `logAEMEvent` function will bypass if platform isn't iOS, it's safe to call without platform determined.
 
 ```ts
-import {AEMReporter} from 'react-native-fbsdk-next';
+import {AEMReporterIOS} from 'react-native-fbsdk-next';
 
-// this will do nothing if Platform.OS !== 'ios'
-AEMReporter.logAEMEvent(eventName, value, currency, otherParameters);
+// this will do nothing if Platform.OS != 'ios'
+AEMReporterIOS.logAEMEvent(eventName, value, currency, otherParameters);
 ```
 
 Event names for AEM must match event names you used in app event logging.

--- a/README.md
+++ b/README.md
@@ -611,6 +611,38 @@ AppEventsLogger.logEvent(AppEventsLogger.AppEvents.CompletedRegistration, {
   [AppEventsLogger.AppEventParams.RegistrationMethod]: "email",
 });
 ```
+### [Aggregated Event Measurement(AEM) for iOS](https://developers.facebook.com/docs/app-events/guides/aggregated-event-measurement/)
+
+Aggregated Event Measurement (AEM) for iOS apps allows for the measurement of app events from iOS 14.5+ users who have opted out of app tracking. To implement AEM for your app you can follow the steps below. 
+
+#### **Step 1. Connect the App Delegate**
+
+Add the following code in the system `application:openURL:options:` function from `AppDelegate`/`SceneDelegate` where `{app-id}` is your Facebook app ID. The call sequence matters.
+
+The DeepLink URL from the re-engagement ads should be passed to the AEM Kit even if the app is opened in cold start.
+
+```objc
+#import <FBAEMKit/FBAEMKit.h>
+
+// apply codes below to `application:openURL:options:` 
+// in `AppDelegate.m` or `SceneDelegate.m`
+[FBAEMReporter configureWithNetworker:nil appID:{app-id}];
+[FBAEMReporter enable];
+[FBAEMReporter handleURL:url];
+```
+
+#### **Step 2. Add AEM Logging**
+
+Use the AEMReporter exported from the sdk to log event to AEM, `logAEMEvent` function will bypass if platform isn't iOS, it's safe to call without platform determined.
+
+```ts
+import {AEMReporter} from 'react-native-fbsdk-next';
+
+// this will do nothing if Platform.OS !== 'ios'
+AEMReporter.logAEMEvent(eventName, value, currency, otherParameters);
+```
+
+Event names for AEM must match event names you used in app event logging.
 
 ### [Graph API](https://developers.facebook.com/docs/graph-api)
 

--- a/ios/RCTFBSDK.xcodeproj/project.pbxproj
+++ b/ios/RCTFBSDK.xcodeproj/project.pbxproj
@@ -23,12 +23,13 @@
 		93E0050F1CE3D2D3000598E3 /* RCTFBSDKGameRequestDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E004FC1CE3D2D3000598E3 /* RCTFBSDKGameRequestDialog.m */; };
 		93E005111CE3D2D3000598E3 /* RCTFBSDKMessageDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E005001CE3D2D3000598E3 /* RCTFBSDKMessageDialog.m */; };
 		93E005121CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E005021CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.m */; };
-		93E005131CE3D2D3000598E3 /* RCTFBSDKShareAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E005041CE3D2D3000598E3 /* RCTFBSDKShareAPI.m */; };
 		93E005141CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E005061CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m */; };
 		93E005151CE3D2D3000598E3 /* RCTFBSDKShareDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E005081CE3D2D3000598E3 /* RCTFBSDKShareDialog.m */; };
 		93E005161CE3D2D3000598E3 /* RCTFBSDKShareHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E0050A1CE3D2D3000598E3 /* RCTFBSDKShareHelper.m */; };
 		B34601D02628529500AC1860 /* RCTFBSDKProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = B34601CF2628529500AC1860 /* RCTFBSDKProfile.m */; };
 		F1191EC92560474100A8767F /* RCTFBSDKAppLink.m in Sources */ = {isa = PBXBuildFile; fileRef = F1191EC82560474100A8767F /* RCTFBSDKAppLink.m */; };
+		F16CE2DB276CAE30003CABEB /* RCTFBSDKSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = F16CE2DA276CAE30003CABEB /* RCTFBSDKSettings.m */; };
+		F1781000276CC2EB0045DEF1 /* RCTFBSDKAEMReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1780FFF276CC2EB0045DEF1 /* RCTFBSDKAEMReporter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -74,18 +75,19 @@
 		93E005001CE3D2D3000598E3 /* RCTFBSDKMessageDialog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKMessageDialog.m; path = share/RCTFBSDKMessageDialog.m; sourceTree = "<group>"; };
 		93E005011CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKSendButtonManager.h; path = share/RCTFBSDKSendButtonManager.h; sourceTree = "<group>"; };
 		93E005021CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKSendButtonManager.m; path = share/RCTFBSDKSendButtonManager.m; sourceTree = "<group>"; };
-		93E005031CE3D2D3000598E3 /* RCTFBSDKShareAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareAPI.h; path = share/RCTFBSDKShareAPI.h; sourceTree = "<group>"; };
-		93E005041CE3D2D3000598E3 /* RCTFBSDKShareAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareAPI.m; path = share/RCTFBSDKShareAPI.m; sourceTree = "<group>"; };
 		93E005051CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareButtonManager.h; path = share/RCTFBSDKShareButtonManager.h; sourceTree = "<group>"; };
 		93E005061CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareButtonManager.m; path = share/RCTFBSDKShareButtonManager.m; sourceTree = "<group>"; };
 		93E005071CE3D2D3000598E3 /* RCTFBSDKShareDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareDialog.h; path = share/RCTFBSDKShareDialog.h; sourceTree = "<group>"; };
 		93E005081CE3D2D3000598E3 /* RCTFBSDKShareDialog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareDialog.m; path = share/RCTFBSDKShareDialog.m; sourceTree = "<group>"; };
 		93E005091CE3D2D3000598E3 /* RCTFBSDKShareHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKShareHelper.h; path = share/RCTFBSDKShareHelper.h; sourceTree = "<group>"; };
 		93E0050A1CE3D2D3000598E3 /* RCTFBSDKShareHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKShareHelper.m; path = share/RCTFBSDKShareHelper.m; sourceTree = "<group>"; };
-		B34601CE2628525600AC1860 /* RCTFBSDKProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTFBSDKProfile.h; sourceTree = "<group>"; };
 		B34601CF2628529500AC1860 /* RCTFBSDKProfile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKProfile.m; path = core/RCTFBSDKProfile.m; sourceTree = "<group>"; };
 		F1191EC82560474100A8767F /* RCTFBSDKAppLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKAppLink.m; path = core/RCTFBSDKAppLink.m; sourceTree = "<group>"; };
 		F1191ECB25604E4B00A8767F /* RCTFBSDKAppLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKAppLink.h; path = core/RCTFBSDKAppLink.h; sourceTree = "<group>"; };
+		F16CE2D8276CAE30003CABEB /* RCTFBSDKProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKProfile.h; path = core/RCTFBSDKProfile.h; sourceTree = "<group>"; };
+		F16CE2D9276CAE30003CABEB /* RCTFBSDKSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTFBSDKSettings.h; path = core/RCTFBSDKSettings.h; sourceTree = "<group>"; };
+		F16CE2DA276CAE30003CABEB /* RCTFBSDKSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKSettings.m; path = core/RCTFBSDKSettings.m; sourceTree = "<group>"; };
+		F1780FFF276CC2EB0045DEF1 /* RCTFBSDKAEMReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTFBSDKAEMReporter.m; path = core/RCTFBSDKAEMReporter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +144,8 @@
 		93E004DA1CE3D286000598E3 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				F16CE2D9276CAE30003CABEB /* RCTFBSDKSettings.h */,
+				F16CE2DA276CAE30003CABEB /* RCTFBSDKSettings.m */,
 				93B905C01D2D987F0013CC92 /* RCTFBSDKGraphRequestConnectionContainer.h */,
 				93B905C11D2D987F0013CC92 /* RCTFBSDKGraphRequestConnectionContainer.m */,
 				93E004DB1CE3D292000598E3 /* RCTConvert+FBSDKAccessToken.h */,
@@ -156,8 +160,9 @@
 				F1191EC82560474100A8767F /* RCTFBSDKAppLink.m */,
 				10E3C0CE2626E85700016645 /* RCTFBSDKAuthenticationToken.m */,
 				10E3C0D12626E87A00016645 /* RCTFBSDKAuthenticationToken.h */,
-				B34601CE2628525600AC1860 /* RCTFBSDKProfile.h */,
+				F16CE2D8276CAE30003CABEB /* RCTFBSDKProfile.h */,
 				B34601CF2628529500AC1860 /* RCTFBSDKProfile.m */,
+				F1780FFF276CC2EB0045DEF1 /* RCTFBSDKAEMReporter.m */,
 			);
 			name = core;
 			sourceTree = "<group>";
@@ -186,8 +191,6 @@
 				93E005001CE3D2D3000598E3 /* RCTFBSDKMessageDialog.m */,
 				93E005011CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.h */,
 				93E005021CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.m */,
-				93E005031CE3D2D3000598E3 /* RCTFBSDKShareAPI.h */,
-				93E005041CE3D2D3000598E3 /* RCTFBSDKShareAPI.m */,
 				93E005051CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.h */,
 				93E005061CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m */,
 				93E005071CE3D2D3000598E3 /* RCTFBSDKShareDialog.h */,
@@ -264,12 +267,13 @@
 				93E005111CE3D2D3000598E3 /* RCTFBSDKMessageDialog.m in Sources */,
 				93E0050F1CE3D2D3000598E3 /* RCTFBSDKGameRequestDialog.m in Sources */,
 				93E004E31CE3D292000598E3 /* RCTConvert+FBSDKAccessToken.m in Sources */,
+				F1781000276CC2EB0045DEF1 /* RCTFBSDKAEMReporter.m in Sources */,
 				10E3C0CF2626E85700016645 /* RCTFBSDKAuthenticationToken.m in Sources */,
 				93E004F01CE3D2B4000598E3 /* RCTFBSDKLoginButtonManager.m in Sources */,
 				93E004EF1CE3D2B4000598E3 /* RCTConvert+FBSDKLogin.m in Sources */,
 				93E005161CE3D2D3000598E3 /* RCTFBSDKShareHelper.m in Sources */,
+				F16CE2DB276CAE30003CABEB /* RCTFBSDKSettings.m in Sources */,
 				93E005141CE3D2D3000598E3 /* RCTFBSDKShareButtonManager.m in Sources */,
-				93E005131CE3D2D3000598E3 /* RCTFBSDKShareAPI.m in Sources */,
 				93E004F11CE3D2B4000598E3 /* RCTFBSDKLoginManager.m in Sources */,
 				F1191EC92560474100A8767F /* RCTFBSDKAppLink.m in Sources */,
 				93E005121CE3D2D3000598E3 /* RCTFBSDKSendButtonManager.m in Sources */,

--- a/ios/RCTFBSDK/core/RCTFBSDKAEMReporter.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAEMReporter.m
@@ -1,0 +1,30 @@
+//
+//  RCTFBSDKAEMReporter.m
+//  react-native-fbsdk-next
+//
+//  Created by rnike@gitub on 2021/12/17.
+//
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTUtils.h>
+#import <FBAEMKit/FBAEMReporter.h>
+
+@interface RCTFBSDKAEMReporter : NSObject <RCTBridgeModule>
+@end
+
+@implementation RCTFBSDKAEMReporter
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(recordAndUpdateEvent:(NSString *)eventName
+                  value:(NSNumber * __nonnull)value
+                  currency:(NSString * _Nullable)currency
+                  otherParameters:(NSDictionary<NSString *,id> * _Nullable)otherParameters)
+{
+    [FBAEMReporter recordAndUpdateEvent:eventName
+                               currency:currency
+                                  value:value
+                             parameters:otherParameters];
+}
+
+@end

--- a/src/FBAEMReporter.ts
+++ b/src/FBAEMReporter.ts
@@ -1,0 +1,45 @@
+/**
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {NativeModules, Platform} from 'react-native';
+
+/**
+ * Aggregated Event Measurement (AEM) for iOS apps allows for the measurement of app events
+ * from iOS 14.5+ users who have opted out of app tracking.
+ *
+ * @ref https://developers.facebook.com/docs/app-events/guides/aggregated-event-measurement/
+ */
+export default {
+  /**
+   * Log AEM event, event names for AEM must match event names you used in app event logging.
+   *
+   * *This method will bypass if platform isn't iOS*
+   *
+   * **Make sure you also handle the DeepLink URL with AEM**
+   *
+   * @ref https://developers.facebook.com/docs/app-events/guides/aggregated-event-measurement/
+   * @platform iOS
+   */
+  logAEMEvent: (
+    eventName: string,
+    value: number,
+    currency?: string,
+    otherParameters?: Record<string, string | number>,
+  ) => {
+    // AEM is currently only for iOS
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+
+    NativeModules.FBSDKAEMReporter.recordAndUpdateEvent(
+      eventName,
+      value,
+      currency,
+      otherParameters,
+    );
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,4 +38,4 @@ export {default as ShareDialog} from './FBShareDialog';
 export {default as LoginButton} from './FBLoginButton';
 export {default as SendButton} from './FBSendButton';
 export {default as ShareButton} from './FBShareButton';
-export {default as AEMReporter} from './FBAEMReporter';
+export {default as AEMReporterIOS} from './FBAEMReporter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export {default as ShareDialog} from './FBShareDialog';
 export {default as LoginButton} from './FBLoginButton';
 export {default as SendButton} from './FBSendButton';
 export {default as ShareButton} from './FBShareButton';
+export {default as AEMReporter} from './FBAEMReporter';


### PR DESCRIPTION
close #153

[Aggregated Event Measurement for Facebook App Events](https://developers.facebook.com/docs/app-events/guides/aggregated-event-measurement/)

1. fix project file issue in `project.pbxproj` (not a serious issue, it's just cannot open some files with xcode when developing this project)
2. create `FBAEMReporter.logAEMEvent` method
3. add a section for AEM in README.md
a. The official document told us to `Add the following to your Podfile: pod 'FBAEMKit'`, but in our case, `FBAEMKit` is already a dependency for `FBSDKCoreKit`, so I didn't mention it in README.md
