### PR TITLE
fix(example)!: Copy package.json to example on example:devcopy

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "example:android": "cd ./RNFBSDKExample && yarn android --no-jetifier",
     "example:clean": "cd RNFBSDKExample && \\rm -fr yarn.lock node_modules ios/Podfile.lock && cd ..",
     "example:install": "cd RNFBSDKExample && yarn && cd ios && (rm -f Podfile.lock && pod install || true) && cd ../..",
-    "example:devcopy": "yarn prepare && cp -rv android ios lib src *.podspec RNFBSDKExample/node_modules/react-native-fbsdk-next/",
+    "example:devcopy": "yarn prepare && cp -rv android ios lib src package.json *.podspec RNFBSDKExample/node_modules/react-native-fbsdk-next/",
     "semantic-release": "semantic-release",
     "jest": "jest"
   },


### PR DESCRIPTION
Currently working on the example project in this repo is a nightmare, I'm trying to change the example into TypeScript but facing some problems.

One of the problems is the file path in the `package.json` is wrong, adding `package.json` to the `example:devcopy` should fix it.