### PR TITLE
fix(android): remove dead code

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -31,8 +31,6 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.share.model.AppGroupCreationContent;
-import com.facebook.share.model.AppInviteContent;
 import com.facebook.share.model.GameRequestContent;
 import com.facebook.share.model.ShareContent;
 import com.facebook.share.model.ShareLinkContent;
@@ -138,29 +136,6 @@ public final class Utility {
             }
         }
         return shareContent;
-    }
-
-    public static AppInviteContent buildAppInviteContent(ReadableMap appInviteContentMap) {
-        AppInviteContent.Builder appInviteContentBuilder = new AppInviteContent.Builder();
-        appInviteContentBuilder.setApplinkUrl(appInviteContentMap.getString("applinkUrl"));
-        if (appInviteContentMap.hasKey("previewImageUrl")) {
-            appInviteContentBuilder.setPreviewImageUrl(appInviteContentMap.getString("previewImageUrl"));
-        }
-        String promotionText = getValueOrNull(appInviteContentMap, "promotionText");
-        String promotionCode = getValueOrNull(appInviteContentMap, "promotionCode");
-        if (promotionText != null && promotionCode != null) {
-            appInviteContentBuilder.setPromotionDetails(promotionText, promotionCode);
-        }
-        return appInviteContentBuilder.build();
-    }
-
-    public static AppGroupCreationContent buildAppGroupCreationContent(ReadableMap appGroupCreationContenMap) {
-        AppGroupCreationContent.Builder appGroupCreationContentBuilder = new AppGroupCreationContent.Builder();
-        appGroupCreationContentBuilder.setName(appGroupCreationContenMap.getString("name"));
-        appGroupCreationContentBuilder.setDescription(appGroupCreationContenMap.getString("description"));
-        appGroupCreationContentBuilder.setAppGroupPrivacy(
-                AppGroupCreationContent.AppGroupPrivacy.valueOf(appGroupCreationContenMap.getString("privacy")));
-        return appGroupCreationContentBuilder.build();
     }
 
     public static GameRequestContent buildGameRequestContent(ReadableMap gameRequestContentMap) {


### PR DESCRIPTION
Willing to fix deprecated calls in `buildAppInviteContent` mentioned in #159, but found out that `buildAppInviteContent` is no longer in use. 

Also found `buildAppGroupCreationContent` is not in use.

Remove `buildAppInviteContent` and `buildAppGroupCreationContent` from Utility.java in this PR.


**Test Plain**
Successfully build an example app for Android.


