### PR TITLE
Fix in IOS Facebook Login when Facebook App Installed

### DIFF
--- a/src/FBLoginManager.js
+++ b/src/FBLoginManager.js
@@ -51,7 +51,8 @@ export type LoginBehaviorAndroid =
 export type LoginBehaviorIOS =
   // Attempts log in through the Safari browser.
   // This is the only behavior supported by the native sdk.
-  'browser';
+  | 'FBSDKLoginBehaviorNative'
+  | 'FBSDKLoginBehaviorWeb';
 /**
  * Shows the results of a login operation.
  */


### PR DESCRIPTION
Fix in IOS Facebook Login when Facebook App Installed:
https://github.com/thebergamo/react-native-fbsdk-next/issues/59#issuecomment-1010838962

I experienced the same issue in IOS 15.2 whereby my  new app would not login via Facebook if the Facebook app was already installed (it logged in when the Facebook app was not installed).

Explanation of fix:

If you open the file [src/FBLoginManager.js](https://github.com/thebergamo/react-native-fbsdk-next/blob/master/src/FBLoginManager.js) you will see the enumerated types of **LoginBehaviorAndroid** and **LoginBehaviorIOS**. 

```
export type LoginBehaviorAndroid =
  // Attempt login in using the Facebook App, and if that does not work fall back to web dialog auth.
  | 'native_with_fallback'
  // Only attempt to login using the Facebook App.
  | 'native_only'
  // Only the web dialog auth should be used.
  | 'web_only';
/**
 * Indicate how Facebook Login should be attempted on iOS.
 */
export type LoginBehaviorIOS =
  // Attempts log in through the Safari browser.
  // This is the only behavior supported by the native sdk.
  'browser';
```
For those who have installed the package in your React Native project you can find the same file under the directory: node_modules/react-native-fbsdk-next/src/FBLoginManager.js.

If you look at the [Facebook Android Documentation](https://developers.facebook.com/docs/reference/android/current/class/LoginBehavior) the enumerated type **LoginBehaviorAndroid** looks like it matches as required.

If you look at the [Facebook IOS Documentation](https://developers.facebook.com/docs/reference/ios/current/class/FBSDKLoginManager) the enumerated type **LoginBehaviorIOS** looks like it doesn't match as required.[](url)

Fixes #59  to automatically close the issue when the PR is merged.

Test Plan (apologies its not thorough - no time):

- Tested fix on React Native 0.67RC6 on IOS 15.2 Physical Device (iPad 8th generation)
- Tried with Facebook App installed and not installed.  Always defaults to using browser for login to Facebook (issue no longer occurs).

Personal motive:
I am new to React Native development (just under a year experience).  I have zero experience in Swift or Objective C so sorry if I have mistakenly followed wrong procedure.  I was just experiencing this bug for my app as well and decided to take on the challenge of resolving myself.  Many thanks to the package maintainers for their contributions.


