### PR TITLE
fix: delete jcenter use to solve problem with outage and future sunset

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,8 +8,9 @@ buildscript {
     // module dependency in an application project.
     if (project == rootProject) {
         repositories {
+            mavenCentral()
             google()
-            jcenter()
+            gradlePluginPortal()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:7.0.3'
@@ -42,6 +43,7 @@ repositories {
     }
     mavenCentral()
     google()
+    gradlePluginPortal()
 }
 
 def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '12.+')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         repositories {
             mavenCentral()
             google()
-            gradlePluginPortal()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:7.0.3'
@@ -43,7 +42,6 @@ repositories {
     }
     mavenCentral()
     google()
-    gradlePluginPortal()
 }
 
 def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '12.+')


### PR DESCRIPTION
Jcenter is down now ([Check status here](https://status.bintray.com)).
It isn't related to the [library sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) because it will be in read mode for a long time but we should replace it.
