### PR TITLE
feat: add clearUserID to AppEventsLogger (`setUserId(null)` throws exception from SDK)

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -260,6 +260,14 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
          mAppEventLogger.setUserID(userID);
      }
 
+    /**
+     * Clears the currently set user id.
+     */
+     @ReactMethod
+     public void clearUserID() {
+         mAppEventLogger.clearUserID();
+     }
+
      /**
       * Returns the set user id or null if not set
       *

--- a/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAppEvents.m
@@ -119,6 +119,11 @@ RCT_EXPORT_METHOD(setUserID:(NSString *)userID)
   [FBSDKAppEvents.shared setUserID:userID];
 }
 
+RCT_EXPORT_METHOD(clearUserID)
+{
+  [FBSDKAppEvents clearUserID];
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getUserID)
 {
   return [FBSDKAppEvents.shared userID];

--- a/jest/mocks/index.js
+++ b/jest/mocks/index.js
@@ -52,6 +52,7 @@ export default {
     logEvent: jest.fn(),
     logPurchase: jest.fn(),
     setUserID: jest.fn(),
+    clearUserID: jest.fn(),
     AppEventParams: mockAppEventParams,
     AppEvents: mockAppEvents,
   },

--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -298,8 +298,15 @@ export default {
    * Sets a custom user ID to associate with all app events.
    * The userID is persisted until it is cleared by passing nil.
    */
-  setUserID(userID: string | null) {
+  setUserID(userID: string) {
     AppEventsLogger.setUserID(userID);
+  },
+
+  /**
+   * Clears the currently set user id.
+   */
+  clearUserID() {
+    AppEventsLogger.clearUserID();
   },
 
   /**

--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -296,7 +296,7 @@ export default {
 
   /**
    * Sets a custom user ID to associate with all app events.
-   * The userID is persisted until it is cleared by passing nil.
+   * The userID is persisted until it is cleared by clearUserID method.
    */
   setUserID(userID: string) {
     AppEventsLogger.setUserID(userID);


### PR DESCRIPTION
Issue occurred when called `setUserID(null)` of AppEventLogger. clearing user id is required when the user signed out.

I found that the `clearUserID` is missing; [facebook-android-sdk](https://github.com/facebook/facebook-android-sdk/blob/9c8d4be04239753a1aa20150520a5778d76aaceb/facebook-core/src/main/java/com/facebook/appevents/AppEventsLogger.kt#L502-L506), [facebook-ios-sdk](https://github.com/facebook/facebook-ios-sdk/blob/3df9d495cde87f1ce895b642524da766b3bd76aa/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m#L679-L682
)

I added clearUserID in this PR.

<img width="397" alt="스크린샷 2022-01-14 오후 7 23 17" src="https://user-images.githubusercontent.com/43715399/149504476-5f25f6bd-e443-4be8-8267-58dcd60b0989.png">
