### PR TITLE
fix(build, typescript): include tsconfig.json in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "LICENSE.txt",
     "README.md",
     "react-native-fbsdk-next.podspec",
-    "jest"
+    "jest",
+    "tsconfig.json"
   ],
   "dependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
Without this file, local builds in node_modules/react-native-fbsdk-next don't work,
and then patch-package isn't as useful
