### PR TITLE
fix(test): safely dereference NativeModule for test compat

### DIFF
--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -134,13 +134,13 @@ export type AppEventParam = {
   ValueYes: string;
 };
 
-const {
-  AppEvents,
-  AppEventParams,
-}: {
-  AppEvents: AppEvent;
-  AppEventParams: AppEventParam;
-} = AppEventsLogger.getConstants();
+let AppEvents: AppEvent | undefined = undefined;
+let AppEventParams: AppEventParam | undefined = undefined;
+if (AppEventsLogger !== undefined) {
+  const constants = AppEventsLogger?.getConstants();
+  AppEvents = constants.AppEvents;
+  AppEventParams = constants.AppEventParams;
+}
 
 export default {
   /**


### PR DESCRIPTION
This allows the module to work unmocked in a jest context

Fixes #188 