### PR TITLE
refactor: make the `getConstants` call cleaner

### DIFF
--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -134,13 +134,7 @@ export type AppEventParam = {
   ValueYes: string;
 };
 
-let AppEvents: AppEvent | undefined = undefined;
-let AppEventParams: AppEventParam | undefined = undefined;
-if (AppEventsLogger !== undefined) {
-  const constants = AppEventsLogger?.getConstants();
-  AppEvents = constants.AppEvents;
-  AppEventParams = constants.AppEventParams;
-}
+const {AppEvents, AppEventParams} = AppEventsLogger?.getConstants() || {};
 
 export default {
   /**


### PR DESCRIPTION
This makes the `AppEventsLogger.getConstants` code cleaner without changing functionality. 

--
Besides, I've made a few tests, the jest will still fail with the error message

 > Invariant Violation: `new NativeEventEmitter()` requires a non-null argument. 

that means the user of this package will need to add 

> jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');

in their jest file.

But after that, if tend to call `AppEventsLogger.logEvent`  in jest will still fail at 

https://github.com/thebergamo/react-native-fbsdk-next/blob/a6c488ee85ebd91ca2b2f203f8d0cf49a937cb2b/src/FBAppEventsLogger.ts#L172

because AppEventsLogger is `undefined` after all.

The simplest way for now I think is to just mock the whole package

> jest.mock('react-native-fbsdk-next)

but in my opinion, for this package's completion, formally having a jest setup is still a `nice to have`, @mikehardy how do you think? I'm willing to work on it, still need some surveys before starting, 

1. Find out why adding `'<rootDir>/node_modules/react-native-fbsdk-next/jest/setup.js` is not working and try fixing it.
or
2. Use `react-native-gesture-handler` method -> https://github.com/software-mansion/react-native-gesture-handler/blob/main/jestSetup.js
or
3. Suggestions are welcome



