### PR TITLE
docs: include example of how to use AEM event logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,9 +652,9 @@ LogFBPurchase = (purchaseAmount: number, currencyCode: string, parameters?: Para
     AEMReporterIOS.logAEMEvent("fb_mobile_purchase", purchaseAmount, currencyCode, parameters);
 }
 
-LogFBEvent = (eventName: string, ...args: Array<number | Params>) => {
-    AppEventsLogger.logEvent(eventName, ...args);
-    AEMReporterIOS.logAEMEvent(eventName, 0, undefined, {});
+LogFBEvent = (eventName: string, valueToSum: number, parameters: Record<string,string | number>)=> {
+    AppEventsLogger.logEvent(eventName, valueToSum, parameters);
+    AEMReporterIOS.logAEMEvent(eventName, valueToSum, parameters.fb_currency, parameters);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -644,6 +644,21 @@ AEMReporterIOS.logAEMEvent(eventName, value, currency, otherParameters);
 
 Event names for AEM must match event names you used in app event logging.
 
+Here's an example of how to use this method - 
+
+```ts
+LogFBPurchase = (purchaseAmount: number, currencyCode: string, parameters?: Params | undefined) => {
+    AppEventsLogger.logPurchase(purchaseAmount, currencyCode, parameters);
+    AEMReporterIOS.logAEMEvent("fb_mobile_purchase", purchaseAmount, currencyCode, parameters);
+}
+
+LogFBEvent = (eventName: string, ...args: Array<number | Params>) => {
+    AppEventsLogger.logEvent(eventName, ...args);
+    AEMReporterIOS.logAEMEvent(eventName, 0, undefined, {});
+}
+```
+
+
 ### [Graph API](https://developers.facebook.com/docs/graph-api)
 
 #### Graph Requests


### PR DESCRIPTION
I was a bit confused when I first saw the new AEM log function - it wasn't clear if I had to use it for purchases as well as regular events, and if so, what event name to use.

So I added some more explanation. Hopefully this is helpful.

One thing that I didn't know how to do was convert the logEvent args (Array<number | Params>) into the Record<string, string | number> type needed for logAEMEvent. Any help on that would be appreciated.