### PR TITLE
feat(ios, sdk): bump facebook-ios-sdk to 12.3.2

### DIFF
--- a/RNFBSDKExample/ios/Podfile.lock
+++ b/RNFBSDKExample/ios/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBAEMKit (12.2.1):
-    - FBSDKCoreKit_Basics (= 12.2.1)
+  - FBAEMKit (12.3.2):
+    - FBSDKCoreKit_Basics (= 12.3.2)
   - FBLazyVector (0.66.4)
   - FBReactNativeSpec (0.66.4):
     - RCT-Folly (= 2021.06.28.00-v2)
@@ -12,14 +12,14 @@ PODS:
     - React-Core (= 0.66.4)
     - React-jsi (= 0.66.4)
     - ReactCommon/turbomodule/core (= 0.66.4)
-  - FBSDKCoreKit (12.2.1):
-    - FBAEMKit (= 12.2.1)
-    - FBSDKCoreKit_Basics (= 12.2.1)
-  - FBSDKCoreKit_Basics (12.2.1)
-  - FBSDKLoginKit (12.2.1):
-    - FBSDKCoreKit (= 12.2.1)
-  - FBSDKShareKit (12.2.1):
-    - FBSDKCoreKit (= 12.2.1)
+  - FBSDKCoreKit (12.3.2):
+    - FBAEMKit (= 12.3.2)
+    - FBSDKCoreKit_Basics (= 12.3.2)
+  - FBSDKCoreKit_Basics (12.3.2)
+  - FBSDKLoginKit (12.3.2):
+    - FBSDKCoreKit (= 12.3.2)
+  - FBSDKShareKit (12.3.2):
+    - FBSDKCoreKit (= 12.3.2)
   - Flipper (0.99.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -288,13 +288,13 @@ PODS:
     - react-native-fbsdk-next/Login (= 7.0.0-beta.3)
     - react-native-fbsdk-next/Share (= 7.0.0-beta.3)
   - react-native-fbsdk-next/Core (7.0.0-beta.3):
-    - FBSDKCoreKit (~> 12.2.1)
+    - FBSDKCoreKit (~> 12.3.2)
     - React-Core
   - react-native-fbsdk-next/Login (7.0.0-beta.3):
-    - FBSDKLoginKit (~> 12.2.1)
+    - FBSDKLoginKit (~> 12.3.2)
     - React-Core
   - react-native-fbsdk-next/Share (7.0.0-beta.3):
-    - FBSDKShareKit (~> 12.2.1)
+    - FBSDKShareKit (~> 12.3.2)
     - React-Core
   - React-perflogger (0.66.4)
   - React-RCTActionSheet (0.66.4):
@@ -511,13 +511,13 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBAEMKit: 4cea610d0bc1680572f2aad7b25db7a2f2690d82
+  FBAEMKit: 955ca52eba8219c20f90774e8c6ff8bc7b3192a3
   FBLazyVector: e5569e42a1c79ca00521846c223173a57aca1fe1
   FBReactNativeSpec: fe08c1cd7e2e205718d77ad14b34957cce949b58
-  FBSDKCoreKit: 5b1992fe65802ca26be7e68bc4fac5f59fa39908
-  FBSDKCoreKit_Basics: a6a92ca628e05f86f458a4721574c5ddfb058ba3
-  FBSDKLoginKit: 7467b7f988ca4fdf48f12a839bcfce4264752429
-  FBSDKShareKit: 25fe0e2cd0811918e5b5b1603cb3fc580154cc48
+  FBSDKCoreKit: 678f64eda3f0ff25c189c2ebbfe87b1d96a85a6d
+  FBSDKCoreKit_Basics: 6bee7c1f0932432901781203fa5e587ec5099148
+  FBSDKLoginKit: 56d55e23fe66a6db045826190b0b4dbc0e1ca0a0
+  FBSDKShareKit: 4ef957addab76816116ea92bd872e792f7137669
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -543,7 +543,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 94ce921e1d8ce7023366873ec371f3441383b396
   React-jsinspector: d0374f7509d407d2264168b6d0fad0b54e300b85
   React-logger: 933f80c97c633ee8965d609876848148e3fef438
-  react-native-fbsdk-next: 6fa3f64e5e29d11eff64bc46e95873a18df39811
+  react-native-fbsdk-next: 27b9700e0187188389af335cbadcbda6d265d363
   React-perflogger: 93075d8931c32cd1fce8a98c15d2d5ccc4d891bd
   React-RCTActionSheet: 7d3041e6761b4f3044a37079ddcb156575fb6d89
   React-RCTAnimation: 743e88b55ac62511ae5c2e22803d4f503f2a3a13

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 12.2.1'
+    ss.dependency     'FBSDKCoreKit', '~> 12.3.2'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 12.2.1'
+    ss.dependency     'FBSDKLoginKit', '~> 12.3.2'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 12.2.1'
+    ss.dependency     'FBSDKShareKit', '~> 12.3.2'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION

Bump facebook-ios-sdk to 12.3.2, ran it locally, seems fine?

Fixes #198 

Note that v13 for both android and ios are out now but they appear to be breaking changes, so, it's good to get a version out with what will likely be the last v12 release before breaking things