### PR TITLE
feat: Add reauthorizeDataAccess method to LoginManager

### DIFF
--- a/RNFBSDKExample/App.js
+++ b/RNFBSDKExample/App.js
@@ -23,7 +23,7 @@
 
 import React, {Component} from 'react';
 import {Alert, StyleSheet, Text, TouchableHighlight, View} from 'react-native';
-import {LoginButton, Settings, ShareDialog} from 'react-native-fbsdk-next';
+import {LoginButton, LoginManager, Settings, ShareDialog} from 'react-native-fbsdk-next';
 
 const SHARE_LINK_CONTENT = {
   contentType: 'link',
@@ -35,6 +35,15 @@ const SHARE_LINK_CONTENT = {
 Settings.initializeSDK();
 
 export default class App extends Component<{}> {
+  _reauthorizeDataAccess = async () => {
+    try {
+      const result = await LoginManager.reauthorizeDataAccess();
+      Alert.alert("Reauthorize data access result", JSON.stringify(result, null, 2));
+    } catch (error) {
+      Alert.alert("Reauthorize data access fail with error:", error);
+    }
+  };
+
   _shareLinkWithShareDialog = async () => {
     const canShow = await ShareDialog.canShow(SHARE_LINK_CONTENT);
     if (canShow) {
@@ -63,7 +72,10 @@ export default class App extends Component<{}> {
           }}
         />
         <TouchableHighlight onPress={this._shareLinkWithShareDialog}>
-          <Text style={styles.shareText}>Share link with ShareDialog</Text>
+          <Text style={styles.buttonText}>Share link with ShareDialog</Text>
+        </TouchableHighlight>
+        <TouchableHighlight onPress={this._reauthorizeDataAccess}>
+          <Text style={styles.buttonText}>Reauthorize Data Access</Text>
         </TouchableHighlight>
       </View>
     );
@@ -77,7 +89,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#F5FCFF',
   },
-  shareText: {
+  buttonText: {
     fontSize: 20,
     margin: 10,
   },

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -146,6 +146,20 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
         }
     }
 
+    /**
+     * Attempts a re-authorization to regain data access.
+     * @param promise Use promise to pass re-authorization result to JS after re-authorization finish.
+     */
+    @ReactMethod
+    public void reauthorizeDataAccess(final Promise promise) {
+        final LoginManager loginManager = LoginManager.getInstance();
+        loginManager.registerCallback(getCallbackManager(), new LoginManagerCallback(promise));
+        Activity activity = getCurrentActivity();
+        if (activity != null) {
+            loginManager.reauthorizeDataAccess(activity);
+        }
+    }
+
     private WritableArray setToWritableArray(Set<String> set) {
         WritableArray array = Arguments.createArray();
         for (String e: set) {

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
@@ -91,14 +91,13 @@ RCT_EXPORT_METHOD(logInWithPermissions:(NSArray<NSString *> *)permissions
          ];
     }
 
-
     [_loginManager
      logInFromViewController: nil
      configuration:configuration
      completion:requestHandler];
 };
 
-RCT_REMAP_METHOD(reauthorizeDataAccess, reauthorizeDataAccess_resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(reauthorizeDataAccess:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     FBSDKLoginManagerLoginResultBlock requestHandler = ^(FBSDKLoginManagerLoginResult *result, NSError *error) {
       if (error) {

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
@@ -77,7 +77,7 @@ RCT_EXPORT_METHOD(logInWithPermissions:(NSArray<NSString *> *)permissions
     };
     FBSDKLoginConfiguration *configuration;
     FBSDKLoginTracking tracking = [loginTracking  isEqualToString: @"limited"] ? FBSDKLoginTrackingLimited : FBSDKLoginTrackingEnabled;
-    
+
     if ( ( ![nonce isEqual:[NSNull null]] ) && ( [nonce length] != 0 ) ) {
         configuration =
         [[FBSDKLoginConfiguration alloc] initWithPermissions:permissions
@@ -90,12 +90,25 @@ RCT_EXPORT_METHOD(logInWithPermissions:(NSArray<NSString *> *)permissions
                                                     tracking: tracking
          ];
     }
-    
-    
+
+
     [_loginManager
      logInFromViewController: nil
      configuration:configuration
      completion:requestHandler];
+};
+
+RCT_REMAP_METHOD(reauthorizeDataAccess, reauthorizeDataAccess_resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    FBSDKLoginManagerLoginResultBlock requestHandler = ^(FBSDKLoginManagerLoginResult *result, NSError *error) {
+      if (error) {
+        reject(@"FacebookSDK", @"Reauthorization Failed", error);
+      } else {
+        resolve(RCTBuildResultDictionary(result));
+      }
+    };
+
+    [_loginManager reauthorizeDataAccess:nil handler:requestHandler];
 };
 
 RCT_EXPORT_METHOD(logOut)

--- a/src/FBLoginManager.ts
+++ b/src/FBLoginManager.ts
@@ -118,8 +118,8 @@ export default {
   },
 
   /**
-  * Re-authorizes the user to update data access permissions.
-  */
+   * Re-authorizes the user to update data access permissions.
+   */
   reauthorizeDataAccess(): Promise<LoginResult> {
     return LoginManager.reauthorizeDataAccess();
   },

--- a/src/FBLoginManager.ts
+++ b/src/FBLoginManager.ts
@@ -118,6 +118,13 @@ export default {
   },
 
   /**
+  * Re-authorizes the user to update data access permissions.
+  */
+  reauthorizeDataAccess(): Promise<LoginResult> {
+    return LoginManager.reauthorizeDataAccess();
+  },
+
+  /**
    * Logs out the user.
    */
   logOut() {


### PR DESCRIPTION
This pull request replicates the functionality added in facebookarchive/react-native-fbsdk#720 in order to facilitate the requesting of data access permissions when they have expired. The native Facebook SDK exposes a method on the LoginManager class (`reauthorizeDataAccess`) that the changes in this pull request exposes to the JS layer. 

Test Plan:

We've modified the example app to call the new method. We've also tested this with a separate app to verify the code is behaving as expected. 