### PR TITLE
fix(types): specify new types output dir after expo plugin addition

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facebook SDK support for React Native apps.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "sideEffects": false,
   "author": {
     "name": "Marcos Bérgamo"


### PR DESCRIPTION

The expo plugin feature in #192 added a `plugin/tsconfig.json` that specifies an output dir

The main bob build is picking that up for some reason, so the types output dir we are referencing in the `types` key of `package.json` is no longer correct, we need to point it one directory in for the new `src` output directory

This works for me locally when I change it in one of my projects
I was unable to quickly reproduce the issue with a jest test to enforce this in the future unfortunately (PRs for that welcome!) so I'll wait to see if someone else on #206 can confirm it works for them

Fixes #206 