### PR TITLE
fix(expo, ios): remove unnecessary compiler_flags in plugin podspec

### DIFF
--- a/ios/ExpoAdapterFBSDKNext.podspec
+++ b/ios/ExpoAdapterFBSDKNext.podspec
@@ -15,8 +15,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/thebergamo/react-native-fbsdk-next.git', :tag => "v#{package['version']}" }
   s.static_framework = true
 
-  s.compiler_flags = %[-DRNBRANCH_VERSION=@\\"#{package["dependencies"]["react-native-fbsdk-next"]}\\"]
-
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
   s.dependency 'FBSDKCoreKit'


### PR DESCRIPTION
Hi, I have a mistake in podspec. This commit will remove unnecessary compiler_flags

