### PR TITLE
fix(types): allow null value for AppEventsLogger.setUserID

### DIFF
--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -290,7 +290,7 @@ export default {
 
   /**
    * Sets a custom user ID to associate with all app events.
-   * The userID is persisted until it is cleared by clearUserID method.
+   * The userID is persisted until this method is called again with a null userId
    */
   setUserID(userID: string | null) {
     AppEventsLogger.setUserID(userID);

--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -292,7 +292,7 @@ export default {
    * Sets a custom user ID to associate with all app events.
    * The userID is persisted until it is cleared by clearUserID method.
    */
-  setUserID(userID: string) {
+  setUserID(userID: string | null) {
     AppEventsLogger.setUserID(userID);
   },
 


### PR DESCRIPTION
AppEventsLogger.clearUserID is deprecated and suggests using "setUserID(null)"
However, setUserID is currently not typed to allow null values.

Test Plan:

no test plan
