### PR TITLE
fix(android, setUserId): temporary android workaround for using setUserID(null)

### DIFF
--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -293,6 +293,11 @@ export default {
    * The userID is persisted until this method is called again with a null userId
    */
   setUserID(userID: string | null) {
+    if (userID === null && Platform.OS === 'android') {
+      // TODO: Remove workaround once https://github.com/facebook/facebook-android-sdk/issues/1047 is released
+      AppEventsLogger.clearUserID();
+      return;
+    }
     AppEventsLogger.setUserID(userID);
   },
 


### PR DESCRIPTION
Follow up to #213 