### PR TITLE
feat(sdks): Update to v13 of native SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,6 @@ import { ShareDialog } from 'react-native-fbsdk-next';
 const shareLinkContent = {
   contentType: 'link',
   contentUrl: "https://facebook.com",
-  contentDescription: 'Wow, check out this great site!',
 };
 
 // ...
@@ -580,7 +579,6 @@ import { ShareApi } from 'react-native-fbsdk-next';
 const shareLinkContent = {
   contentType: 'link',
   contentUrl: "https://facebook.com",
-  contentDescription: 'Wow, check out this great site!',
 };
 
 // ...

--- a/RNFBSDKExample/ios/Podfile.lock
+++ b/RNFBSDKExample/ios/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBAEMKit (12.3.2):
-    - FBSDKCoreKit_Basics (= 12.3.2)
+  - FBAEMKit (13.1.0):
+    - FBSDKCoreKit_Basics (= 13.1.0)
   - FBLazyVector (0.67.2)
   - FBReactNativeSpec (0.67.2):
     - RCT-Folly (= 2021.06.28.00-v2)
@@ -12,14 +12,18 @@ PODS:
     - React-Core (= 0.67.2)
     - React-jsi (= 0.67.2)
     - ReactCommon/turbomodule/core (= 0.67.2)
-  - FBSDKCoreKit (12.3.2):
-    - FBAEMKit (= 12.3.2)
-    - FBSDKCoreKit_Basics (= 12.3.2)
-  - FBSDKCoreKit_Basics (12.3.2)
-  - FBSDKLoginKit (12.3.2):
-    - FBSDKCoreKit (= 12.3.2)
-  - FBSDKShareKit (12.3.2):
-    - FBSDKCoreKit (= 12.3.2)
+  - FBSDKCoreKit (13.1.0):
+    - FBAEMKit (= 13.1.0)
+    - FBSDKCoreKit_Basics (= 13.1.0)
+  - FBSDKCoreKit_Basics (13.1.0)
+  - FBSDKGamingServicesKit (13.1.0):
+    - FBSDKCoreKit (= 13.1.0)
+    - FBSDKCoreKit_Basics (= 13.1.0)
+    - FBSDKShareKit (= 13.1.0)
+  - FBSDKLoginKit (13.1.0):
+    - FBSDKCoreKit (= 13.1.0)
+  - FBSDKShareKit (13.1.0):
+    - FBSDKCoreKit (= 13.1.0)
   - Flipper (0.99.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -282,19 +286,20 @@ PODS:
   - React-jsinspector (0.67.2)
   - React-logger (0.67.2):
     - glog
-  - react-native-fbsdk-next (7.1.0):
+  - react-native-fbsdk-next (7.3.3):
     - React-Core
-    - react-native-fbsdk-next/Core (= 7.1.0)
-    - react-native-fbsdk-next/Login (= 7.1.0)
-    - react-native-fbsdk-next/Share (= 7.1.0)
-  - react-native-fbsdk-next/Core (7.1.0):
-    - FBSDKCoreKit (~> 12.3.2)
+    - react-native-fbsdk-next/Core (= 7.3.3)
+    - react-native-fbsdk-next/Login (= 7.3.3)
+    - react-native-fbsdk-next/Share (= 7.3.3)
+  - react-native-fbsdk-next/Core (7.3.3):
+    - FBSDKCoreKit (~> 13.1.0)
     - React-Core
-  - react-native-fbsdk-next/Login (7.1.0):
-    - FBSDKLoginKit (~> 12.3.2)
+  - react-native-fbsdk-next/Login (7.3.3):
+    - FBSDKLoginKit (~> 13.1.0)
     - React-Core
-  - react-native-fbsdk-next/Share (7.1.0):
-    - FBSDKShareKit (~> 12.3.2)
+  - react-native-fbsdk-next/Share (7.3.3):
+    - FBSDKGamingServicesKit (~> 13.1.0)
+    - FBSDKShareKit (~> 13.1.0)
     - React-Core
   - React-perflogger (0.67.2)
   - React-RCTActionSheet (0.67.2):
@@ -428,6 +433,7 @@ SPEC REPOS:
     - FBAEMKit
     - FBSDKCoreKit
     - FBSDKCoreKit_Basics
+    - FBSDKGamingServicesKit
     - FBSDKLoginKit
     - FBSDKShareKit
     - Flipper
@@ -512,13 +518,14 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBAEMKit: 955ca52eba8219c20f90774e8c6ff8bc7b3192a3
+  FBAEMKit: 9ce89760a23f03ffecd907c8e1f3201160f2dcc7
   FBLazyVector: 244195e30d63d7f564c55da4410b9a24e8fbceaa
   FBReactNativeSpec: c94002c1d93da3658f4d5119c6994d19961e3d52
-  FBSDKCoreKit: 678f64eda3f0ff25c189c2ebbfe87b1d96a85a6d
-  FBSDKCoreKit_Basics: 6bee7c1f0932432901781203fa5e587ec5099148
-  FBSDKLoginKit: 56d55e23fe66a6db045826190b0b4dbc0e1ca0a0
-  FBSDKShareKit: 4ef957addab76816116ea92bd872e792f7137669
+  FBSDKCoreKit: eff97dea778dbe6cc4498959cffb619c75675102
+  FBSDKCoreKit_Basics: c151609a1cf6976a5958febcf0043266a8fd5151
+  FBSDKGamingServicesKit: c05d00fe9d6a01c484ae8b025915b778fabc1944
+  FBSDKLoginKit: 42932c7ad6f6b91854fc0a6bcc79b7e807bcde4b
+  FBSDKShareKit: ba73d5d51af028bfc9e6fa34be16340fe055e0fa
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
@@ -544,7 +551,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 52beb652bbc61201bd70cbe4f0b8edb607e8da4f
   React-jsinspector: 595f76eba2176ebd8817a1fffd47b84fbdab9383
   React-logger: 23de8ea0f44fa00ee77e96060273225607fd4d78
-  react-native-fbsdk-next: 7fa197c23545e36aa7549ef1ede3a63669981bc5
+  react-native-fbsdk-next: 447b2ffafedecf5fe9a99c35023099d38fa31fda
   React-perflogger: 3c9bb7372493e49036f07a82c44c8cf65cbe88db
   React-RCTActionSheet: 052606483045a408693aa7e864410b4a052f541a
   React-RCTAnimation: 08d4cac13222bb1348c687a0158dfd3b577cdb63

--- a/RNFBSDKExample/ios/RNFBSDKExample.xcodeproj/project.pbxproj
+++ b/RNFBSDKExample/ios/RNFBSDKExample.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		6F42E5EA98685FBE727AD68D /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5ABCB82D3C55B520AED9AD70 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		D23CBF841BDE50868ED73973 /* libPods-RNFBSDKExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C500945E9AE0ABF95A77D925 /* libPods-RNFBSDKExample.a */; };
+		C9654CFD18664A5E3CB7772A /* libPods-RNFBSDKExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FBB99C19935EAEEB6EBC319 /* libPods-RNFBSDKExample.a */; };
+		D014B9EF2FA3510E228B1412 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B41EF6F0EB71524760B1B5F /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,13 +36,13 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = RNFBSDKExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNFBSDKExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = RNFBSDKExample/main.m; sourceTree = "<group>"; };
-		5ABCB82D3C55B520AED9AD70 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample-RNFBSDKExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F70647361ED008DA6FE2EA4 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		25A6739DA345EB177B209F0D /* Pods-RNFBSDKExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.release.xcconfig"; sourceTree = "<group>"; };
+		4B41EF6F0EB71524760B1B5F /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample-RNFBSDKExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B604F9FE1B6A9F6BE432B0D /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNFBSDKExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		A6918D19E88113DEDD5254D0 /* Pods-RNFBSDKExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.debug.xcconfig"; sourceTree = "<group>"; };
-		A92BECAAC6CC31E9273A3AD6 /* Pods-RNFBSDKExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.release.xcconfig"; sourceTree = "<group>"; };
-		C500945E9AE0ABF95A77D925 /* libPods-RNFBSDKExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C9857DEE7692C5A02A18A56E /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		DBD8608F0B8E6E40F3876455 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		930723FC02E82786AD867D30 /* Pods-RNFBSDKExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNFBSDKExample.debug.xcconfig"; path = "Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample.debug.xcconfig"; sourceTree = "<group>"; };
+		9FBB99C19935EAEEB6EBC319 /* libPods-RNFBSDKExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNFBSDKExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -51,7 +51,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6F42E5EA98685FBE727AD68D /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */,
+				D014B9EF2FA3510E228B1412 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D23CBF841BDE50868ED73973 /* libPods-RNFBSDKExample.a in Frameworks */,
+				C9654CFD18664A5E3CB7772A /* libPods-RNFBSDKExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,22 +100,10 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				C500945E9AE0ABF95A77D925 /* libPods-RNFBSDKExample.a */,
-				5ABCB82D3C55B520AED9AD70 /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */,
+				9FBB99C19935EAEEB6EBC319 /* libPods-RNFBSDKExample.a */,
+				4B41EF6F0EB71524760B1B5F /* libPods-RNFBSDKExample-RNFBSDKExampleTests.a */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		805AC489D252A6316A65B08C /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				A6918D19E88113DEDD5254D0 /* Pods-RNFBSDKExample.debug.xcconfig */,
-				A92BECAAC6CC31E9273A3AD6 /* Pods-RNFBSDKExample.release.xcconfig */,
-				DBD8608F0B8E6E40F3876455 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */,
-				C9857DEE7692C5A02A18A56E /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -133,7 +121,7 @@
 				00E356EF1AD99517003FC87E /* RNFBSDKExampleTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				805AC489D252A6316A65B08C /* Pods */,
+				D51585C1484B31EBE12F9BD1 /* Pods */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -149,6 +137,18 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		D51585C1484B31EBE12F9BD1 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				930723FC02E82786AD867D30 /* Pods-RNFBSDKExample.debug.xcconfig */,
+				25A6739DA345EB177B209F0D /* Pods-RNFBSDKExample.release.xcconfig */,
+				6B604F9FE1B6A9F6BE432B0D /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */,
+				1F70647361ED008DA6FE2EA4 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -156,12 +156,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "RNFBSDKExampleTests" */;
 			buildPhases = (
-				DAB1AD489EF3E4E3BEC7C92E /* [CP] Check Pods Manifest.lock */,
+				E6DA2504A29AE077D174D1F1 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				256E354B566F9B5798928405 /* [CP] Embed Pods Frameworks */,
-				211846C22590395B68632A5E /* [CP] Copy Pods Resources */,
+				A8D1CB0CB69769B719E46380 /* [CP] Embed Pods Frameworks */,
+				E9B2A734B30558A61E6CB8B3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -177,14 +177,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "RNFBSDKExample" */;
 			buildPhases = (
-				0745896823CEC88E327935CB /* [CP] Check Pods Manifest.lock */,
+				235861EF15039C72DFF4BACA /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				ADE8698076809F4AEAB1D72D /* [CP] Embed Pods Frameworks */,
-				0ABB427C26D574D275F7D326 /* [CP] Copy Pods Resources */,
+				551748CC33A105EE0E765E60 /* [CP] Embed Pods Frameworks */,
+				478F5EEBA80EA26F212822B2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -265,7 +265,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nexport NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		0745896823CEC88E327935CB /* [CP] Check Pods Manifest.lock */ = {
+		235861EF15039C72DFF4BACA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -287,7 +287,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		0ABB427C26D574D275F7D326 /* [CP] Copy Pods Resources */ = {
+		478F5EEBA80EA26F212822B2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -304,41 +304,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		211846C22590395B68632A5E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		256E354B566F9B5798928405 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		ADE8698076809F4AEAB1D72D /* [CP] Embed Pods Frameworks */ = {
+		551748CC33A105EE0E765E60 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -355,7 +321,24 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample/Pods-RNFBSDKExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DAB1AD489EF3E4E3BEC7C92E /* [CP] Check Pods Manifest.lock */ = {
+		A8D1CB0CB69769B719E46380 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E6DA2504A29AE077D174D1F1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -375,6 +358,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E9B2A734B30558A61E6CB8B3 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RNFBSDKExample-RNFBSDKExampleTests/Pods-RNFBSDKExample-RNFBSDKExampleTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -429,7 +429,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DBD8608F0B8E6E40F3876455 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */;
+			baseConfigurationReference = 6B604F9FE1B6A9F6BE432B0D /* Pods-RNFBSDKExample-RNFBSDKExampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				EXCLUDED_ARCHS = i386;
@@ -458,7 +458,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C9857DEE7692C5A02A18A56E /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */;
+			baseConfigurationReference = 1F70647361ED008DA6FE2EA4 /* Pods-RNFBSDKExample-RNFBSDKExampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -484,7 +484,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A6918D19E88113DEDD5254D0 /* Pods-RNFBSDKExample.debug.xcconfig */;
+			baseConfigurationReference = 930723FC02E82786AD867D30 /* Pods-RNFBSDKExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -512,7 +512,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A92BECAAC6CC31E9273A3AD6 /* Pods-RNFBSDKExample.release.xcconfig */;
+			baseConfigurationReference = 25A6739DA345EB177B209F0D /* Pods-RNFBSDKExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ repositories {
     google()
 }
 
-def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '12.+')
+def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '13.+')
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -168,10 +168,6 @@ public final class Utility {
     public static ShareLinkContent buildShareLinkContent(ReadableMap shareLinkContent) {
         ShareLinkContent.Builder contentBuilder = new ShareLinkContent.Builder();
         contentBuilder.setContentUrl(Uri.parse(shareLinkContent.getString("contentUrl")));
-        String url = getValueOrNull(shareLinkContent, "imageUrl");
-        contentBuilder.setImageUrl(url != null ? Uri.parse(url) : null);
-        contentBuilder.setContentDescription(getValueOrNull(shareLinkContent, "contentDescription"));
-        contentBuilder.setContentTitle(getValueOrNull(shareLinkContent, "contentTitle"));
         contentBuilder.setQuote(getValueOrNull(shareLinkContent, "quote"));
         appendGenericContent(contentBuilder, shareLinkContent);
         return contentBuilder.build();

--- a/ios/RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m
+++ b/ios/RCTFBSDK/share/RCTConvert+FBSDKSharingContent.m
@@ -55,7 +55,7 @@ static void RCTAppendGenericContent(RCTFBSDKSharingContent contentObject, NSDict
     contentObject.peopleIDs = [RCTConvert NSStringArray:contentData[@"peopleIds"]];
     contentObject.placeID = [RCTConvert NSString:contentData[@"placeId"]];
     contentObject.ref = [RCTConvert NSString:contentData[@"ref"]];
-    contentObject.hashtag = [FBSDKHashtag hashtagWithString:[RCTConvert NSString:contentData[@"hashtag"]]];
+    contentObject.hashtag = [[FBSDKHashtag alloc] initWithString: [RCTConvert NSString:contentData[@"hashtag"]]];
   }
 }
 
@@ -88,7 +88,7 @@ static FBSDKSharePhoto *RCTBuildPhoto(NSDictionary *photoData)
 {
   UIImage *image = [RCTConvert UIImage:photoData[@"imageUrl"]];
   BOOL userGenerated = [RCTConvert BOOL:photoData[@"userGenerated"]];
-  FBSDKSharePhoto *photo = [FBSDKSharePhoto photoWithImage:image userGenerated:userGenerated];
+  FBSDKSharePhoto *photo =[ [FBSDKSharePhoto alloc] initWithImage:image isUserGenerated:userGenerated];
   photo.caption = [RCTConvert NSString:photoData[@"caption"]];
   return photo;
 }
@@ -98,7 +98,7 @@ static FBSDKShareVideoContent *RCTBuildVideoContent(NSDictionary *contentData)
   FBSDKShareVideoContent *videoContent = [[FBSDKShareVideoContent alloc] init];
   NSDictionary *videoData = [RCTConvert NSDictionary:contentData[@"video"]];
   NSURL *videoURL = [RCTConvert NSURL:videoData[@"localUrl"]];
-  FBSDKShareVideo *video = [FBSDKShareVideo videoWithVideoURL:videoURL];
+  FBSDKShareVideo *video = [[FBSDKShareVideo alloc] initWithVideoURL:videoURL previewPhoto:nil];
   if (contentData[@"previewPhoto"]) {
     FBSDKSharePhoto *previewPhoto = RCTBuildPhoto([RCTConvert NSDictionary:contentData[@"previewPhoto"]]);
     video.previewPhoto = previewPhoto;

--- a/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.h
+++ b/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.h
@@ -18,7 +18,7 @@
 
 #import <React/RCTBridgeModule.h>
 
-#import <FBSDKShareKit/FBSDKShareKit.h>
+@import FBSDKGamingServicesKit;
 
 @interface RCTFBSDKGameRequestDialog : NSObject <RCTBridgeModule>
 @end

--- a/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
@@ -73,8 +73,8 @@ RCT_EXPORT_MODULE(FBGameRequestDialog);
 - (instancetype)init
 {
   if ((self = [super init])) {
-    _dialog = [[FBSDKGameRequestDialog alloc] init];
-    _dialog.delegate = self;
+    // Content can't be null, how should this be initialized?
+    _dialog = [[FBSDKGameRequestDialog alloc] initWithContent:nil delegate:self];
   }
   return self;
 }

--- a/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
@@ -73,8 +73,9 @@ RCT_EXPORT_MODULE(FBGameRequestDialog);
 - (instancetype)init
 {
   if ((self = [super init])) {
-    // Content can't be null, how should this be initialized?
-    _dialog = [[FBSDKGameRequestDialog alloc] initWithContent:nil delegate:self];
+    // Is no longer possible to initialize a dialog without content
+    FBSDKGameRequestContent *emptyContent = [[FBSDKGameRequestContent alloc] init];
+    _dialog = [[FBSDKGameRequestDialog alloc] initWithContent:emptyContent delegate:self];
   }
   return self;
 }

--- a/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
@@ -44,8 +44,7 @@ RCT_EXPORT_MODULE(FBMessageDialog);
 - (instancetype)init
 {
   if ((self = [super init])) {
-    _dialog = [[FBSDKMessageDialog alloc] init];
-    _dialog.delegate = self;
+    _dialog = [[FBSDKMessageDialog alloc] initWithContent:nil delegate:self];
   }
   return self;
 }

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Share' do |ss|
     ss.dependency     'FBSDKShareKit', '~> 13.1.0'
+    ss.dependency     'FBSDKGamingServicesKit', '~> 13.1.0'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -10,21 +10,21 @@ Pod::Spec.new do |s|
   s.license       = package['license']
   s.homepage      = package['homepage']
   s.source        = { :git => 'https://github.com/thebergamo/react-native-fbsdk-next.git', :tag => "v#{package['version']}" }
-  s.platforms     = { :ios => "10.0", :tvos => "10.0" }
+  s.platforms     = { :ios => "11.0", :tvos => "11.0" }
   s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 12.3.2'
+    ss.dependency     'FBSDKCoreKit', '~> 13.1.0'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 12.3.2'
+    ss.dependency     'FBSDKLoginKit', '~> 13.1.0'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 12.3.2'
+    ss.dependency     'FBSDKShareKit', '~> 13.1.0'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
This is a PR for updating the library to the latest FB sdk as raised on #208 

Facebook post introducing the new version [here](https://developers.facebook.com/blog/post/2022/02/24/introducing-facebook-platform-sdk-13-related-updates/)

# iOS Changes

Please refer to the official changelog [here](https://github.com/facebook/facebook-ios-sdk/blob/main/CHANGELOG.md), main things to note are:

```
The minimum supported version of iOS is now 11.0 for all frameworks. 
The minimum supported version of tvOS is now 11.0 for all frameworks. 
The XCFramework binaries are now built with Xcode 13 so Xcode 12 is no longer supported.
```

```
Starting with the v13.0 release, client tokens must be included in apps for Graph API calls. 
An exception is now raised when running apps without a client token.
```

### Breaking changes

None

# Android Changes

Please refer to the official changelog [here](https://github.com/facebook/facebook-android-sdk/blob/main/CHANGELOG.md), main things to note are:

```
Set Java source and target compatibility to 1.8 (Java 8). 
All apps that integrate with Facebook Android SDK should also set source and compatibility to 1.8 or above.
```

```
GMS AD_ID Permission is added to the SDK by default for requesting the advertising ID
```

```
Removed the support for tokenless requests. 
Now all Graph API requests must be associated with an access token and the app needs to have a client token to construct the access token without a logged in user.
```

### Breaking changes

On android the deprecated ShareLink parameters `contentDescription`, `contentTitle` and `imageUrl` have now been removed.


Regarding the testing plan I would appreciate suggestions as well.