### PR TITLE
fix(jest): add LoginManager.logOut + AccessToken mocks

### DIFF
--- a/jest/mocks/index.js
+++ b/jest/mocks/index.js
@@ -48,6 +48,10 @@ export const mockAppEventParams = {
 };
 
 export default {
+  AccessToken: {
+    refreshCurrentAccessTokenAsync: jest.fn(),
+    getCurrentAccessToken: jest.fn(),
+  },
   AppEventsLogger: {
     logEvent: jest.fn(),
     logPurchase: jest.fn(),

--- a/jest/mocks/index.js
+++ b/jest/mocks/index.js
@@ -58,6 +58,7 @@ export default {
   },
   LoginManager: {
     logInWithPermissions: jest.fn(),
+    logOut: jest.fn(),
   },
   Settings: {
     initializeSDK: jest.fn(),


### PR DESCRIPTION
Fix issue where `jest.spyOn(LoginManager, 'logOut')` would raise `Cannot spy the logOut property because it is not a function; undefined given instead`