### PR TITLE
fix(ios): use facebook-ios-sdk 13.2.0 / archive with Xcode < 13.3

### DIFF
--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -14,18 +14,18 @@ Pod::Spec.new do |s|
   s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 13.1.0'
+    ss.dependency     'FBSDKCoreKit', '~> 13.2.0'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 13.1.0'
+    ss.dependency     'FBSDKLoginKit', '~> 13.2.0'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 13.1.0'
-    ss.dependency     'FBSDKGamingServicesKit', '~> 13.1.0'
+    ss.dependency     'FBSDKShareKit', '~> 13.2.0'
+    ss.dependency     'FBSDKGamingServicesKit', '~> 13.2.0'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION

Should fix an archive error on iOS

See: https://github.com/facebook/facebook-ios-sdk/issues/2062#issuecomment-1117736024
Fixes #244

Test Plan:

- Should have no regressions
- @caiorrsdeg or myself can verify it archives on Xcode 13.2.1 (most recent Xcode available for macOS 11 machines)