### PR TITLE
fix(expo, ios): add client token to info plist (fixes #228)

### DIFF
--- a/plugin/build/withFacebookIOS.d.ts
+++ b/plugin/build/withFacebookIOS.d.ts
@@ -11,6 +11,7 @@ export declare function setFacebookAutoInitEnabled(config: ConfigProps, { Facebo
 export declare function setFacebookAutoLogAppEventsEnabled(config: ConfigProps, { FacebookAutoLogAppEventsEnabled: _, ...infoPlist }: InfoPlist): InfoPlist;
 export declare function setFacebookAdvertiserIDCollectionEnabled(config: ConfigProps, { FacebookAdvertiserIDCollectionEnabled: _, ...infoPlist }: InfoPlist): InfoPlist;
 export declare function setFacebookAppId(config: ConfigProps, { FacebookAppID: _, ...infoPlist }: InfoPlist): InfoPlist;
+export declare function setFacebookClientToken(config: ConfigProps, { FacebookClientToken: _, ...infoPlist }: InfoPlist): InfoPlist;
 export declare function setFacebookDisplayName(config: ConfigProps, { FacebookDisplayName: _, ...infoPlist }: InfoPlist): InfoPlist;
 export declare function setFacebookApplicationQuerySchemes(config: ConfigProps, infoPlist: InfoPlist): InfoPlist;
 export declare const withUserTrackingPermission: ConfigPlugin<{

--- a/plugin/build/withFacebookIOS.d.ts
+++ b/plugin/build/withFacebookIOS.d.ts
@@ -1,10 +1,6 @@
 import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
 import { ConfigProps } from './config';
 export declare const withFacebookIOS: ConfigPlugin<ConfigProps>;
-/**
- * Getters
- * TODO: these getters are the same between ios/android, we could reuse them
- */
 export declare function setFacebookConfig(config: ConfigProps, infoPlist: InfoPlist): InfoPlist;
 export declare function setFacebookScheme(config: ConfigProps, infoPlist: InfoPlist): InfoPlist;
 export declare function setFacebookAutoInitEnabled(config: ConfigProps, { FacebookAutoInitEnabled: _, ...infoPlist }: InfoPlist): InfoPlist;

--- a/plugin/build/withFacebookIOS.js
+++ b/plugin/build/withFacebookIOS.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withUserTrackingPermission = exports.setFacebookApplicationQuerySchemes = exports.setFacebookDisplayName = exports.setFacebookAppId = exports.setFacebookAdvertiserIDCollectionEnabled = exports.setFacebookAutoLogAppEventsEnabled = exports.setFacebookAutoInitEnabled = exports.setFacebookScheme = exports.setFacebookConfig = exports.withFacebookIOS = void 0;
+exports.withUserTrackingPermission = exports.setFacebookApplicationQuerySchemes = exports.setFacebookDisplayName = exports.setFacebookClientToken = exports.setFacebookAppId = exports.setFacebookAdvertiserIDCollectionEnabled = exports.setFacebookAutoLogAppEventsEnabled = exports.setFacebookAutoInitEnabled = exports.setFacebookScheme = exports.setFacebookConfig = exports.withFacebookIOS = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const config_1 = require("./config");
 const { Scheme } = config_plugins_1.IOSConfig;
@@ -20,6 +20,7 @@ exports.withFacebookIOS = withFacebookIOS;
  */
 function setFacebookConfig(config, infoPlist) {
     infoPlist = setFacebookAppId(config, infoPlist);
+    infoPlist = setFacebookClientToken(config, infoPlist);
     infoPlist = setFacebookApplicationQuerySchemes(config, infoPlist);
     infoPlist = setFacebookDisplayName(config, infoPlist);
     infoPlist = setFacebookAutoInitEnabled(config, infoPlist);
@@ -85,6 +86,17 @@ function setFacebookAppId(config, { FacebookAppID: _, ...infoPlist }) {
     return infoPlist;
 }
 exports.setFacebookAppId = setFacebookAppId;
+function setFacebookClientToken(config, { FacebookClientToken: _, ...infoPlist }) {
+    const clientToken = (0, config_1.getFacebookClientToken)(config);
+    if (clientToken) {
+        return {
+            ...infoPlist,
+            FacebookClientToken: clientToken,
+        };
+    }
+    return infoPlist;
+}
+exports.setFacebookClientToken = setFacebookClientToken;
 function setFacebookDisplayName(config, { FacebookDisplayName: _, ...infoPlist }) {
     const facebookDisplayName = (0, config_1.getFacebookDisplayName)(config);
     if (facebookDisplayName) {

--- a/plugin/build/withFacebookIOS.js
+++ b/plugin/build/withFacebookIOS.js
@@ -14,10 +14,6 @@ const withFacebookIOS = (config, props) => {
     });
 };
 exports.withFacebookIOS = withFacebookIOS;
-/**
- * Getters
- * TODO: these getters are the same between ios/android, we could reuse them
- */
 function setFacebookConfig(config, infoPlist) {
     infoPlist = setFacebookAppId(config, infoPlist);
     infoPlist = setFacebookClientToken(config, infoPlist);

--- a/plugin/src/__tests__/withFacebookIOS-test.ts
+++ b/plugin/src/__tests__/withFacebookIOS-test.ts
@@ -9,6 +9,7 @@ import {
 import {
   setFacebookAdvertiserIDCollectionEnabled,
   setFacebookAppId,
+  setFacebookClientToken,
   setFacebookAutoInitEnabled,
   setFacebookConfig,
 } from '../withFacebookIOS';
@@ -51,6 +52,12 @@ describe('ios facebook config', () => {
     });
   });
 
+  it('sets the facebook client token config', () => {
+    expect(setFacebookClientToken({ clientToken: 'abc' }, {})).toStrictEqual({
+      FacebookClientToken: 'abc',
+    });
+  });
+
   it('sets the facebook auto init config', () => {
     expect(
       setFacebookAutoInitEnabled({ isAutoInitEnabled: true }, {})
@@ -77,6 +84,7 @@ describe('ios facebook config', () => {
         {
           FacebookAdvertiserIDCollectionEnabled: true,
           FacebookAppID: 'my-app-id',
+          FacebookClientToken: 'my-client-token',
           FacebookAutoInitEnabled: true,
           FacebookAutoLogAppEventsEnabled: true,
           FacebookDisplayName: 'my-display-name',

--- a/plugin/src/withFacebookIOS.ts
+++ b/plugin/src/withFacebookIOS.ts
@@ -8,6 +8,7 @@ import {
   ConfigProps,
   getFacebookAdvertiserIDCollection,
   getFacebookAppId,
+  getFacebookClientToken,
   getFacebookAutoInitEnabled,
   getFacebookAutoLogAppEvents,
   getFacebookDisplayName,
@@ -36,6 +37,7 @@ export const withFacebookIOS: ConfigPlugin<ConfigProps> = (config, props) => {
 
 export function setFacebookConfig(config: ConfigProps, infoPlist: InfoPlist) {
   infoPlist = setFacebookAppId(config, infoPlist);
+  infoPlist = setFacebookClientToken(config, infoPlist);
   infoPlist = setFacebookApplicationQuerySchemes(config, infoPlist);
   infoPlist = setFacebookDisplayName(config, infoPlist);
   infoPlist = setFacebookAutoInitEnabled(config, infoPlist);
@@ -117,6 +119,21 @@ export function setFacebookAppId(
     return {
       ...infoPlist,
       FacebookAppID: appID,
+    };
+  }
+
+  return infoPlist;
+}
+
+export function setFacebookClientToken(
+  config: ConfigProps,
+  { FacebookClientToken: _, ...infoPlist }: InfoPlist
+): InfoPlist {
+  const clientToken = getFacebookClientToken(config);
+  if (clientToken) {
+    return {
+      ...infoPlist,
+      FacebookClientToken: clientToken,
     };
   }
 

--- a/plugin/src/withFacebookIOS.ts
+++ b/plugin/src/withFacebookIOS.ts
@@ -30,11 +30,6 @@ export const withFacebookIOS: ConfigPlugin<ConfigProps> = (config, props) => {
   });
 };
 
-/**
- * Getters
- * TODO: these getters are the same between ios/android, we could reuse them
- */
-
 export function setFacebookConfig(config: ConfigProps, infoPlist: InfoPlist) {
   infoPlist = setFacebookAppId(config, infoPlist);
   infoPlist = setFacebookClientToken(config, infoPlist);


### PR DESCRIPTION
I'm in the process of migrating from `expo-facebook` to this library. Thereby I ran into the issue mentioned in #228, where the new SDK requires the facebook client token to be set in the info plist. This PR adds the client token to the expo config plugin, so that the workaround does not need to be used.