### PR TITLE
fix(expo, ios): pass through config for ios user tracking permission

### DIFF
--- a/plugin/build/config.js
+++ b/plugin/build/config.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getFacebookAdvertiserIDCollection = exports.getFacebookAutoLogAppEvents = exports.getFacebookAutoInitEnabled = exports.getFacebookDisplayName = exports.getFacebookScheme = exports.getFacebookClientToken = exports.getFacebookAppId = exports.getMergePropsWithConfig = void 0;
 function getMergePropsWithConfig(config, props) {
     const { facebookAppId, facebookDisplayName, facebookScheme, facebookAutoInitEnabled, facebookAutoLogAppEventsEnabled, facebookAdvertiserIDCollectionEnabled, } = config;
-    const { appID = facebookAppId, clientToken, displayName = facebookDisplayName, scheme = facebookScheme !== null && facebookScheme !== void 0 ? facebookScheme : (appID ? `fb${appID}` : undefined), isAutoInitEnabled = facebookAutoInitEnabled !== null && facebookAutoInitEnabled !== void 0 ? facebookAutoInitEnabled : false, autoLogAppEventsEnabled = facebookAutoLogAppEventsEnabled !== null && facebookAutoLogAppEventsEnabled !== void 0 ? facebookAutoLogAppEventsEnabled : false, advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled !== null && facebookAdvertiserIDCollectionEnabled !== void 0 ? facebookAdvertiserIDCollectionEnabled : false, } = (props !== null && props !== void 0 ? props : {});
+    const { appID = facebookAppId, clientToken, displayName = facebookDisplayName, scheme = facebookScheme !== null && facebookScheme !== void 0 ? facebookScheme : (appID ? `fb${appID}` : undefined), isAutoInitEnabled = facebookAutoInitEnabled !== null && facebookAutoInitEnabled !== void 0 ? facebookAutoInitEnabled : false, autoLogAppEventsEnabled = facebookAutoLogAppEventsEnabled !== null && facebookAutoLogAppEventsEnabled !== void 0 ? facebookAutoLogAppEventsEnabled : false, advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled !== null && facebookAdvertiserIDCollectionEnabled !== void 0 ? facebookAdvertiserIDCollectionEnabled : false, iosUserTrackingPermission, } = (props !== null && props !== void 0 ? props : {});
     return {
         appID,
         clientToken,
@@ -12,6 +12,7 @@ function getMergePropsWithConfig(config, props) {
         isAutoInitEnabled,
         autoLogAppEventsEnabled,
         advertiserIDCollectionEnabled,
+        iosUserTrackingPermission,
     };
 }
 exports.getMergePropsWithConfig = getMergePropsWithConfig;

--- a/plugin/src/__tests__/withUserTrackingPermission-test.ts
+++ b/plugin/src/__tests__/withUserTrackingPermission-test.ts
@@ -1,0 +1,73 @@
+import {withUserTrackingPermission} from '../withFacebookIOS';
+
+describe(withUserTrackingPermission, () => {
+  it(`skips adding the permission when false`, () => {
+    expect(
+      withUserTrackingPermission(
+        {name: 'foo', slug: 'bar'},
+        {iosUserTrackingPermission: false},
+      ),
+    ).toEqual({
+      name: 'foo',
+      slug: 'bar',
+    });
+  });
+
+  it(`sets custom user tracking description`, () => {
+    expect(
+      withUserTrackingPermission(
+        {name: 'foo', slug: 'bar'},
+        {iosUserTrackingPermission: 'custom tracking description'},
+      ),
+    ).toEqual({
+      name: 'foo',
+      slug: 'bar',
+      ios: {
+        infoPlist: {
+          NSUserTrackingUsageDescription: 'custom tracking description',
+        },
+      },
+    });
+  });
+
+  it(`adds default user tracking description`, () => {
+    expect(
+      withUserTrackingPermission({name: 'foo', slug: 'bar'}, {}),
+    ).toStrictEqual({
+      name: 'foo',
+      slug: 'bar',
+      ios: {
+        infoPlist: {
+          NSUserTrackingUsageDescription:
+            'This identifier will be used to deliver personalized ads to you.',
+        },
+      },
+    });
+  });
+
+  it(`does not overwrite existing user tracking description`, () => {
+    expect(
+      withUserTrackingPermission(
+        {
+          name: 'foo',
+          slug: 'bar',
+          ios: {
+            infoPlist: {
+              NSUserTrackingUsageDescription:
+                'existing user tracking description',
+            },
+          },
+        },
+        {},
+      ),
+    ).toStrictEqual({
+      name: 'foo',
+      slug: 'bar',
+      ios: {
+        infoPlist: {
+          NSUserTrackingUsageDescription: 'existing user tracking description',
+        },
+      },
+    });
+  });
+});

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -66,6 +66,7 @@ export function getMergePropsWithConfig(
     isAutoInitEnabled = facebookAutoInitEnabled ?? false,
     autoLogAppEventsEnabled = facebookAutoLogAppEventsEnabled ?? false,
     advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled ?? false,
+    iosUserTrackingPermission,
   } = (props ?? {}) as ConfigProps;
 
   return {
@@ -76,6 +77,7 @@ export function getMergePropsWithConfig(
     isAutoInitEnabled,
     autoLogAppEventsEnabled,
     advertiserIDCollectionEnabled,
+    iosUserTrackingPermission,
   };
 }
 


### PR DESCRIPTION
When trying to submit an update via App Store Connect, I was greeted with following issue:

<img width="1138" alt="Screenshot 2022-05-12 at 09 39 26" src="https://user-images.githubusercontent.com/1851359/168017793-159a0e63-2449-4864-a282-3d9ccdd69ef8.png">

The cause for this is that the expo plugin config variable `iosUserTrackingPermission` is not passed through. Thus the `withUserTrackingPermission` sub-function will always add the default user tracking permission string. This pull request fixes this.

Test Plan:
I linked this package locally and ran `expo prebuild` once with the change and once without, while checking `ios/MyProject/Info.plist` for `NSUserTrackingUsageDescription`. Without change, it is present. With change, it is gone.

--

I have also added tests for `withUserTrackingPermission`. Please let me know if you'd like to keep them. The tests would not have found the issue, since they only test the `withUserTrackingPermission` function.

It would be possible to either convert the existing tests or to add new tests in a more e2e-style by invoking the main plugin function `withFacebook` and then checking the output. What is your opinion on this?