### PR TITLE
refactor(formatting): expand prettier scope to include jest and plugin files

### DIFF
--- a/jest/mocks/index.js
+++ b/jest/mocks/index.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 const LoginButton = require('../../lib/commonjs/FBLoginButton').default;
 
-
 export const mockAppEvents = {
   AchievedLevel: 'fb_mobile_level_achieved',
   AdClick: 'AdClick',

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "typescript": "^4.5.5"
   },
   "prettier": {
-    "requirePragma": true,
     "singleQuote": true,
     "trailingComma": "all",
     "bracketSpacing": false,

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint": "eslint ./src",
     "test": "yarn validate:prettier && yarn validate:eslint && yarn jest",
     "validate:eslint": "eslint \"src/**/*\"",
-    "validate:prettier": "prettier \"src/**/*.{ts,tsx}\" --check",
+    "validate:prettier": "prettier \"{src,jest,plugin/src}/**/*.{js,ts,tsx}\" --check",
     "validate:ts": "tsc --noEmit",
     "example:start": "cd ./RNFBSDKExample && yarn start",
     "example:ios": "cd ./RNFBSDKExample/ios && rm -f Podfile.lock && pod install && yarn ios",

--- a/plugin/src/__tests__/withFacebookAndroid-test.ts
+++ b/plugin/src/__tests__/withFacebookAndroid-test.ts
@@ -1,7 +1,3 @@
-import { AndroidConfig } from '@expo/config-plugins';
-import { resolve } from 'path';
-import { Parser } from 'xml2js';
-
 import {
   getFacebookAdvertiserIDCollection,
   getFacebookAppId,
@@ -10,14 +6,17 @@ import {
   getFacebookDisplayName,
   getFacebookScheme,
 } from '../config';
-import { setFacebookConfig } from '../withFacebookAndroid';
+import {setFacebookConfig} from '../withFacebookAndroid';
+import {AndroidConfig} from '@expo/config-plugins';
+import {resolve} from 'path';
+import {Parser} from 'xml2js';
 
-const { getMainApplication, readAndroidManifestAsync } = AndroidConfig.Manifest;
+const {getMainApplication, readAndroidManifestAsync} = AndroidConfig.Manifest;
 
 const fixturesPath = resolve(__dirname, 'fixtures');
 const sampleManifestPath = resolve(
   fixturesPath,
-  'react-native-AndroidManifest.xml'
+  'react-native-AndroidManifest.xml',
 );
 
 const filledManifest = `<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
@@ -75,31 +74,25 @@ describe('Android facebook config', () => {
   });
 
   it(`returns correct value from all getters if value provided`, () => {
-    expect(getFacebookScheme({ scheme: 'fbmyscheme' })).toMatch(
-      'fbmyscheme'
+    expect(getFacebookScheme({scheme: 'fbmyscheme'})).toMatch('fbmyscheme');
+    expect(getFacebookAppId({appID: 'my-app-id'})).toMatch('my-app-id');
+    expect(getFacebookDisplayName({displayName: 'my-display-name'})).toMatch(
+      'my-display-name',
     );
-    expect(getFacebookAppId({ appID: 'my-app-id' })).toMatch(
-      'my-app-id'
+    expect(getFacebookAutoLogAppEvents({autoLogAppEventsEnabled: false})).toBe(
+      false,
     );
-    expect(
-      getFacebookDisplayName({ displayName: 'my-display-name' })
-    ).toMatch('my-display-name');
-    expect(
-      getFacebookAutoLogAppEvents({ autoLogAppEventsEnabled: false })
-    ).toBe(false);
-    expect(getFacebookAutoInitEnabled({ isAutoInitEnabled: true })).toBe(
-      true
-    );
+    expect(getFacebookAutoInitEnabled({isAutoInitEnabled: true})).toBe(true);
     expect(
       getFacebookAdvertiserIDCollection({
         advertiserIDCollectionEnabled: false,
-      })
+      }),
     ).toBe(false);
   });
 
   it('adds scheme, appid, display name, autolog events, auto init, advertiser id collection to androidmanifest.xml', async () => {
     let androidManifestJson = await readAndroidManifestAsync(
-      sampleManifestPath
+      sampleManifestPath,
     );
     const facebookConfig = {
       appID: 'my-app-id',
@@ -111,12 +104,12 @@ describe('Android facebook config', () => {
     };
     androidManifestJson = setFacebookConfig(
       facebookConfig,
-      androidManifestJson
+      androidManifestJson,
     );
     // Run this twice to ensure copies don't get added.
     androidManifestJson = setFacebookConfig(
       facebookConfig,
-      androidManifestJson
+      androidManifestJson,
     );
 
     const mainApplication = getMainApplication(androidManifestJson);
@@ -125,49 +118,50 @@ describe('Android facebook config', () => {
     }
 
     const facebookActivity = mainApplication.activity?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.CustomTabActivity'
+      (e) => e.$['android:name'] === 'com.facebook.CustomTabActivity',
     );
     expect(facebookActivity).toHaveLength(1);
 
     const applicationId = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationId'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationId',
     );
     expect(applicationId).toHaveLength(1);
     expect(applicationId?.[0].$['android:value']).toMatch(
-      '@string/facebook_app_id'
+      '@string/facebook_app_id',
     );
 
     const displayName = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationName'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationName',
     );
     expect(displayName).toHaveLength(1);
     expect(displayName?.[0].$['android:value']).toMatch(
-      facebookConfig.displayName
+      facebookConfig.displayName,
     );
 
     const autoLogAppEventsEnabled = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoLogAppEventsEnabled'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoLogAppEventsEnabled',
     );
     expect(autoLogAppEventsEnabled).toHaveLength(1);
     expect(autoLogAppEventsEnabled?.[0].$['android:value']).toMatch(
-      facebookConfig.autoLogAppEventsEnabled.toString()
+      facebookConfig.autoLogAppEventsEnabled.toString(),
     );
 
     const advertiserIDCollectionEnabled = mainApplication['meta-data']?.filter(
       (e) =>
-        e.$['android:name'] === 'com.facebook.sdk.AdvertiserIDCollectionEnabled'
+        e.$['android:name'] ===
+        'com.facebook.sdk.AdvertiserIDCollectionEnabled',
     );
     expect(advertiserIDCollectionEnabled).toHaveLength(1);
     expect(advertiserIDCollectionEnabled?.[0].$['android:value']).toMatch(
-      facebookConfig.advertiserIDCollectionEnabled.toString()
+      facebookConfig.advertiserIDCollectionEnabled.toString(),
     );
 
     const autoInitEnabled = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoInitEnabled'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoInitEnabled',
     );
     expect(autoInitEnabled).toHaveLength(1);
     expect(autoInitEnabled?.[0].$['android:value']).toMatch(
-      facebookConfig.isAutoInitEnabled.toString()
+      facebookConfig.isAutoInitEnabled.toString(),
     );
   });
 
@@ -178,7 +172,7 @@ describe('Android facebook config', () => {
     const facebookConfig = {};
     androidManifestJson = setFacebookConfig(
       facebookConfig,
-      androidManifestJson
+      androidManifestJson,
     );
 
     const mainApplication = getMainApplication(androidManifestJson);
@@ -187,32 +181,33 @@ describe('Android facebook config', () => {
     }
 
     const facebookActivity = mainApplication.activity?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.CustomTabActivity'
+      (e) => e.$['android:name'] === 'com.facebook.CustomTabActivity',
     );
     expect(facebookActivity).toHaveLength(0);
     const applicationId = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationId'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationId',
     );
     expect(applicationId).toHaveLength(0);
 
     const displayName = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationName'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationName',
     );
     expect(displayName).toHaveLength(0);
 
     const autoLogAppEventsEnabled = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoLogAppEventsEnabled'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoLogAppEventsEnabled',
     );
     expect(autoLogAppEventsEnabled).toHaveLength(0);
 
     const advertiserIDCollectionEnabled = mainApplication['meta-data']?.filter(
       (e) =>
-        e.$['android:name'] === 'com.facebook.sdk.AdvertiserIDCollectionEnabled'
+        e.$['android:name'] ===
+        'com.facebook.sdk.AdvertiserIDCollectionEnabled',
     );
     expect(advertiserIDCollectionEnabled).toHaveLength(0);
 
     const autoInitEnabled = mainApplication['meta-data']?.filter(
-      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoInitEnabled'
+      (e) => e.$['android:name'] === 'com.facebook.sdk.AutoInitEnabled',
     );
     expect(autoInitEnabled).toHaveLength(0);
   });

--- a/plugin/src/__tests__/withFacebookIOS-test.ts
+++ b/plugin/src/__tests__/withFacebookIOS-test.ts
@@ -13,6 +13,7 @@ import {
   setFacebookAutoInitEnabled,
   setFacebookConfig,
 } from '../withFacebookIOS';
+
 describe('ios facebook config', () => {
   it(`returns null from all getters if no value provided`, () => {
     expect(getFacebookScheme({})).toBe(null);
@@ -24,43 +25,37 @@ describe('ios facebook config', () => {
   });
 
   it(`returns correct value from all getters if value provided`, () => {
-    expect(getFacebookScheme({ scheme: 'fbscheme' })).toMatch(
-      'fbscheme'
+    expect(getFacebookScheme({scheme: 'fbscheme'})).toMatch('fbscheme');
+    expect(getFacebookAppId({appID: 'my-app-id'})).toMatch('my-app-id');
+    expect(getFacebookDisplayName({displayName: 'my-display-name'})).toMatch(
+      'my-display-name',
     );
-    expect(getFacebookAppId({ appID: 'my-app-id' })).toMatch(
-      'my-app-id'
+    expect(getFacebookAutoLogAppEvents({autoLogAppEventsEnabled: false})).toBe(
+      false,
     );
-    expect(
-      getFacebookDisplayName({ displayName: 'my-display-name' })
-    ).toMatch('my-display-name');
-    expect(
-      getFacebookAutoLogAppEvents({ autoLogAppEventsEnabled: false })
-    ).toBe(false);
-    expect(getFacebookAutoInitEnabled({ isAutoInitEnabled: true })).toBe(
-      true
-    );
+    expect(getFacebookAutoInitEnabled({isAutoInitEnabled: true})).toBe(true);
     expect(
       getFacebookAdvertiserIDCollection({
         advertiserIDCollectionEnabled: false,
-      })
+      }),
     ).toBe(false);
   });
 
   it('sets the facebook app id config', () => {
-    expect(setFacebookAppId({ appID: 'abc' }, {})).toStrictEqual({
+    expect(setFacebookAppId({appID: 'abc'}, {})).toStrictEqual({
       FacebookAppID: 'abc',
     });
   });
 
   it('sets the facebook client token config', () => {
-    expect(setFacebookClientToken({ clientToken: 'abc' }, {})).toStrictEqual({
+    expect(setFacebookClientToken({clientToken: 'abc'}, {})).toStrictEqual({
       FacebookClientToken: 'abc',
     });
   });
 
   it('sets the facebook auto init config', () => {
     expect(
-      setFacebookAutoInitEnabled({ isAutoInitEnabled: true }, {})
+      setFacebookAutoInitEnabled({isAutoInitEnabled: true}, {}),
     ).toStrictEqual({
       FacebookAutoInitEnabled: true,
     });
@@ -69,9 +64,9 @@ describe('ios facebook config', () => {
   it('sets the facebook advertising id enabled config', () => {
     expect(
       setFacebookAdvertiserIDCollectionEnabled(
-        { advertiserIDCollectionEnabled: true },
-        {}
-      )
+        {advertiserIDCollectionEnabled: true},
+        {},
+      ),
     ).toStrictEqual({
       FacebookAdvertiserIDCollectionEnabled: true,
     });
@@ -94,8 +89,8 @@ describe('ios facebook config', () => {
             'fbauth2',
             'fbshareextension',
           ],
-        }
-      )
+        },
+      ),
     ).toStrictEqual({});
   });
   it('preserves the existing LSApplicationQueriesSchemes after removing the facebook schemes', () => {
@@ -109,7 +104,7 @@ describe('ios facebook config', () => {
           'fbauth2',
           'fbshareextension',
         ],
-      }
+      },
     );
     // Test that running the command twice doesn't cause duplicates
     expect(setFacebookConfig({}, plist)).toStrictEqual({

--- a/plugin/src/__tests__/withSKAdNetworkIdentifiers-test.ts
+++ b/plugin/src/__tests__/withSKAdNetworkIdentifiers-test.ts
@@ -1,11 +1,16 @@
-import { withSKAdNetworkIdentifiers } from '../withSKAdNetworkIdentifiers';
+import {withSKAdNetworkIdentifiers} from '../withSKAdNetworkIdentifiers';
 
 describe(withSKAdNetworkIdentifiers, () => {
   it(`adds ids to the Info.plist`, () => {
-    expect(withSKAdNetworkIdentifiers({
-      name: 'foo',
-      slug: 'bar',
-    }, ['FOOBAR', 'other'])).toStrictEqual({
+    expect(
+      withSKAdNetworkIdentifiers(
+        {
+          name: 'foo',
+          slug: 'bar',
+        },
+        ['FOOBAR', 'other'],
+      ),
+    ).toStrictEqual({
       name: 'foo',
       slug: 'bar',
       ios: {
@@ -38,8 +43,8 @@ describe(withSKAdNetworkIdentifiers, () => {
             },
           },
         },
-        ['foobar', 'other']
-      )
+        ['foobar', 'other'],
+      ),
     ).toStrictEqual({
       name: 'foo',
       slug: 'bar',

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config-types';
+import {ExpoConfig} from '@expo/config-types';
 
 export type ExpoConfigFacebook = Pick<
   ExpoConfig,
@@ -48,7 +48,7 @@ export type ConfigProps = {
 
 export function getMergePropsWithConfig(
   config: ExpoConfigFacebook,
-  props: ConfigProps | void
+  props: ConfigProps | void,
 ): ConfigProps {
   const {
     facebookAppId,
@@ -65,7 +65,8 @@ export function getMergePropsWithConfig(
     scheme = facebookScheme ?? (appID ? `fb${appID}` : undefined),
     isAutoInitEnabled = facebookAutoInitEnabled ?? false,
     autoLogAppEventsEnabled = facebookAutoLogAppEventsEnabled ?? false,
-    advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled ?? false,
+    advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled ??
+      false,
     iosUserTrackingPermission,
   } = (props ?? {}) as ConfigProps;
 

--- a/plugin/src/withFacebook.ts
+++ b/plugin/src/withFacebook.ts
@@ -1,13 +1,12 @@
-import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
-import { ConfigProps, getMergePropsWithConfig } from './config';
-
+import {ConfigProps, getMergePropsWithConfig} from './config';
 import {
   withAndroidPermissions,
   withFacebookAppIdString,
   withFacebookManifest,
 } from './withFacebookAndroid';
-import { withFacebookIOS, withUserTrackingPermission } from './withFacebookIOS';
-import { withSKAdNetworkIdentifiers } from './withSKAdNetworkIdentifiers';
+import {withFacebookIOS, withUserTrackingPermission} from './withFacebookIOS';
+import {withSKAdNetworkIdentifiers} from './withSKAdNetworkIdentifiers';
+import {ConfigPlugin, createRunOncePlugin} from '@expo/config-plugins';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('react-native-fbsdk-next/package.json');

--- a/plugin/src/withFacebookAndroid.ts
+++ b/plugin/src/withFacebookAndroid.ts
@@ -1,14 +1,4 @@
 import {
-  AndroidConfig,
-  ConfigPlugin,
-  withAndroidManifest,
-  withStringsXml,
-} from '@expo/config-plugins';
-import {
-  appendScheme,
-  hasScheme,
-} from '@expo/config-plugins/build/android/Scheme';
-import {
   ConfigProps,
   getFacebookAdvertiserIDCollection,
   getFacebookAppId,
@@ -18,9 +8,19 @@ import {
   getFacebookDisplayName,
   getFacebookScheme,
 } from './config';
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  withAndroidManifest,
+  withStringsXml,
+} from '@expo/config-plugins';
+import {
+  appendScheme,
+  hasScheme,
+} from '@expo/config-plugins/build/android/Scheme';
 
-const { buildResourceItem } = AndroidConfig.Resources;
-const { removeStringItem, setStringItem } = AndroidConfig.Strings;
+const {buildResourceItem} = AndroidConfig.Resources;
+const {removeStringItem, setStringItem} = AndroidConfig.Strings;
 const {
   addMetaDataItemToMainApplication,
   getMainApplicationOrThrow,
@@ -41,17 +41,17 @@ const META_AD_ID_COLLECTION = 'com.facebook.sdk.AdvertiserIDCollectionEnabled';
 
 export const withFacebookAppIdString: ConfigPlugin<ConfigProps> = (
   config,
-  props
+  props,
 ) => {
   return withStringsXml(config, (config) => {
     config.modResults = applyFacebookAppIdString(props, config.modResults);
     config.modResults = applyFacebookClientTokenString(
       props,
-      config.modResults
+      config.modResults,
     );
     config.modResults = applyFacebookLoginProtocolSchemeString(
       props,
-      config.modResults
+      config.modResults,
     );
     return config;
   });
@@ -59,7 +59,7 @@ export const withFacebookAppIdString: ConfigPlugin<ConfigProps> = (
 
 export const withFacebookManifest: ConfigPlugin<ConfigProps> = (
   config,
-  props
+  props,
 ) => {
   return withAndroidManifest(config, (config) => {
     config.modResults = setFacebookConfig(props, config.modResults);
@@ -81,13 +81,13 @@ function buildXMLItem({
   head: Record<string, string>;
   children?: Record<string, string | any[]>;
 }) {
-  return { ...(children ?? {}), $: head };
+  return {...(children ?? {}), $: head};
 }
 
 function buildAndroidItem(datum: string | Record<string, any>) {
-  const item = typeof datum === 'string' ? { name: datum } : datum;
+  const item = typeof datum === 'string' ? {name: datum} : datum;
   const head = prefixAndroidKeys(item);
-  return buildXMLItem({ head });
+  return buildXMLItem({head});
 }
 
 function getFacebookSchemeActivity() {
@@ -117,7 +117,7 @@ function getFacebookSchemeActivity() {
             buildAndroidItem('android.intent.category.BROWSABLE'),
           ],
           data: [
-            buildAndroidItem({ scheme: '@string/fb_login_protocol_scheme' }),
+            buildAndroidItem({scheme: '@string/fb_login_protocol_scheme'}),
           ],
         },
       ],
@@ -150,7 +150,7 @@ function ensureFacebookActivity({
 
 function applyFacebookLoginProtocolSchemeString(
   props: ConfigProps,
-  stringsJSON: AndroidConfig.Resources.ResourceXML
+  stringsJSON: AndroidConfig.Resources.ResourceXML,
 ) {
   const scheme = getFacebookScheme(props);
   if (scheme) {
@@ -161,7 +161,7 @@ function applyFacebookLoginProtocolSchemeString(
           value: scheme,
         }),
       ],
-      stringsJSON
+      stringsJSON,
     );
   }
 
@@ -170,13 +170,13 @@ function applyFacebookLoginProtocolSchemeString(
 
 function applyFacebookAppIdString(
   props: ConfigProps,
-  stringsJSON: AndroidConfig.Resources.ResourceXML
+  stringsJSON: AndroidConfig.Resources.ResourceXML,
 ) {
   const appID = getFacebookAppId(props);
   if (appID) {
     return setStringItem(
-      [buildResourceItem({ name: STRING_FACEBOOK_APP_ID, value: appID })],
-      stringsJSON
+      [buildResourceItem({name: STRING_FACEBOOK_APP_ID, value: appID})],
+      stringsJSON,
     );
   }
 
@@ -185,7 +185,7 @@ function applyFacebookAppIdString(
 
 function applyFacebookClientTokenString(
   props: ConfigProps,
-  stringsJSON: AndroidConfig.Resources.ResourceXML
+  stringsJSON: AndroidConfig.Resources.ResourceXML,
 ) {
   const clientToken = getFacebookClientToken(props);
   if (clientToken) {
@@ -196,7 +196,7 @@ function applyFacebookClientTokenString(
           value: clientToken,
         }),
       ],
-      stringsJSON
+      stringsJSON,
     );
   }
 
@@ -205,7 +205,7 @@ function applyFacebookClientTokenString(
 
 export function setFacebookConfig(
   props: ConfigProps,
-  androidManifest: AndroidConfig.Manifest.AndroidManifest
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
 ) {
   const scheme = getFacebookScheme(props);
 
@@ -223,18 +223,18 @@ export function setFacebookConfig(
     androidManifest = appendScheme(scheme, androidManifest);
   }
 
-  mainApplication = ensureFacebookActivity({ scheme, mainApplication });
+  mainApplication = ensureFacebookActivity({scheme, mainApplication});
 
   if (appID) {
     mainApplication = addMetaDataItemToMainApplication(
       mainApplication,
       META_APP_ID,
-      `@string/${STRING_FACEBOOK_APP_ID}`
+      `@string/${STRING_FACEBOOK_APP_ID}`,
     );
   } else {
     mainApplication = removeMetaDataItemFromMainApplication(
       mainApplication,
-      META_APP_ID
+      META_APP_ID,
     );
   }
 
@@ -242,12 +242,12 @@ export function setFacebookConfig(
     mainApplication = addMetaDataItemToMainApplication(
       mainApplication,
       META_CLIENT_TOKEN,
-      `@string/${STRING_FACEBOOK_CLIENT_TOKEN}`
+      `@string/${STRING_FACEBOOK_CLIENT_TOKEN}`,
     );
   } else {
     mainApplication = removeMetaDataItemFromMainApplication(
       mainApplication,
-      META_CLIENT_TOKEN
+      META_CLIENT_TOKEN,
     );
   }
 
@@ -255,49 +255,49 @@ export function setFacebookConfig(
     mainApplication = addMetaDataItemToMainApplication(
       mainApplication,
       META_APP_NAME,
-      displayName
+      displayName,
     );
   } else {
     mainApplication = removeMetaDataItemFromMainApplication(
       mainApplication,
-      META_APP_NAME
+      META_APP_NAME,
     );
   }
   if (autoInitEnabled !== null) {
     mainApplication = addMetaDataItemToMainApplication(
       mainApplication,
       META_AUTO_INIT,
-      autoInitEnabled ? 'true' : 'false'
+      autoInitEnabled ? 'true' : 'false',
     );
   } else {
     mainApplication = removeMetaDataItemFromMainApplication(
       mainApplication,
-      META_AUTO_INIT
+      META_AUTO_INIT,
     );
   }
   if (autoLogAppEvents !== null) {
     mainApplication = addMetaDataItemToMainApplication(
       mainApplication,
       META_AUTO_LOG_APP_EVENTS,
-      autoLogAppEvents ? 'true' : 'false'
+      autoLogAppEvents ? 'true' : 'false',
     );
   } else {
     mainApplication = removeMetaDataItemFromMainApplication(
       mainApplication,
-      META_AUTO_LOG_APP_EVENTS
+      META_AUTO_LOG_APP_EVENTS,
     );
   }
   if (advertiserIdCollection !== null) {
     mainApplication = addMetaDataItemToMainApplication(
       mainApplication,
       META_AD_ID_COLLECTION,
-      advertiserIdCollection ? 'true' : 'false'
+      advertiserIdCollection ? 'true' : 'false',
     );
   } else {
     // eslint-disable-next-line
     mainApplication = removeMetaDataItemFromMainApplication(
       mainApplication,
-      META_AD_ID_COLLECTION
+      META_AD_ID_COLLECTION,
     );
   }
 

--- a/plugin/src/withFacebookIOS.ts
+++ b/plugin/src/withFacebookIOS.ts
@@ -1,10 +1,4 @@
 import {
-  ConfigPlugin,
-  InfoPlist,
-  IOSConfig,
-  withInfoPlist,
-} from '@expo/config-plugins';
-import {
   ConfigProps,
   getFacebookAdvertiserIDCollection,
   getFacebookAppId,
@@ -14,9 +8,15 @@ import {
   getFacebookDisplayName,
   getFacebookScheme,
 } from './config';
+import {
+  ConfigPlugin,
+  InfoPlist,
+  IOSConfig,
+  withInfoPlist,
+} from '@expo/config-plugins';
 
-const { Scheme } = IOSConfig;
-const { appendScheme } = Scheme;
+const {Scheme} = IOSConfig;
+const {appendScheme} = Scheme;
 
 const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
 
@@ -49,8 +49,8 @@ export function setFacebookScheme(config: ConfigProps, infoPlist: InfoPlist) {
   }
 
   if (
-    infoPlist.CFBundleURLTypes?.some(({ CFBundleURLSchemes }) =>
-      CFBundleURLSchemes.includes(facebookScheme)
+    infoPlist.CFBundleURLTypes?.some(({CFBundleURLSchemes}) =>
+      CFBundleURLSchemes.includes(facebookScheme),
     )
   ) {
     return infoPlist;
@@ -61,7 +61,7 @@ export function setFacebookScheme(config: ConfigProps, infoPlist: InfoPlist) {
 
 export function setFacebookAutoInitEnabled(
   config: ConfigProps,
-  { FacebookAutoInitEnabled: _, ...infoPlist }: InfoPlist
+  {FacebookAutoInitEnabled: _, ...infoPlist}: InfoPlist,
 ): InfoPlist {
   const isAutoInitEnabled = getFacebookAutoInitEnabled(config);
   if (isAutoInitEnabled === null) {
@@ -76,7 +76,7 @@ export function setFacebookAutoInitEnabled(
 
 export function setFacebookAutoLogAppEventsEnabled(
   config: ConfigProps,
-  { FacebookAutoLogAppEventsEnabled: _, ...infoPlist }: InfoPlist
+  {FacebookAutoLogAppEventsEnabled: _, ...infoPlist}: InfoPlist,
 ): InfoPlist {
   const autoLogAppEventsEnabled = getFacebookAutoLogAppEvents(config);
   if (autoLogAppEventsEnabled === null) {
@@ -91,7 +91,7 @@ export function setFacebookAutoLogAppEventsEnabled(
 
 export function setFacebookAdvertiserIDCollectionEnabled(
   config: ConfigProps,
-  { FacebookAdvertiserIDCollectionEnabled: _, ...infoPlist }: InfoPlist
+  {FacebookAdvertiserIDCollectionEnabled: _, ...infoPlist}: InfoPlist,
 ): InfoPlist {
   const advertiserIDCollectionEnabled =
     getFacebookAdvertiserIDCollection(config);
@@ -107,7 +107,7 @@ export function setFacebookAdvertiserIDCollectionEnabled(
 
 export function setFacebookAppId(
   config: ConfigProps,
-  { FacebookAppID: _, ...infoPlist }: InfoPlist
+  {FacebookAppID: _, ...infoPlist}: InfoPlist,
 ): InfoPlist {
   const appID = getFacebookAppId(config);
   if (appID) {
@@ -122,7 +122,7 @@ export function setFacebookAppId(
 
 export function setFacebookClientToken(
   config: ConfigProps,
-  { FacebookClientToken: _, ...infoPlist }: InfoPlist
+  {FacebookClientToken: _, ...infoPlist}: InfoPlist,
 ): InfoPlist {
   const clientToken = getFacebookClientToken(config);
   if (clientToken) {
@@ -137,7 +137,7 @@ export function setFacebookClientToken(
 
 export function setFacebookDisplayName(
   config: ConfigProps,
-  { FacebookDisplayName: _, ...infoPlist }: InfoPlist
+  {FacebookDisplayName: _, ...infoPlist}: InfoPlist,
 ): InfoPlist {
   const facebookDisplayName = getFacebookDisplayName(config);
   if (facebookDisplayName) {
@@ -152,7 +152,7 @@ export function setFacebookDisplayName(
 
 export function setFacebookApplicationQuerySchemes(
   config: ConfigProps,
-  infoPlist: InfoPlist
+  infoPlist: InfoPlist,
 ): InfoPlist {
   const facebookAppId = getFacebookAppId(config);
 
@@ -163,7 +163,7 @@ export function setFacebookApplicationQuerySchemes(
     return infoPlist;
   } else if (!facebookAppId && !existingSchemes.length) {
     // already removed, no need to strip again
-    const { LSApplicationQueriesSchemes, ...restInfoPlist } = infoPlist;
+    const {LSApplicationQueriesSchemes, ...restInfoPlist} = infoPlist;
     if (LSApplicationQueriesSchemes?.length) {
       return infoPlist;
     } else {
@@ -200,9 +200,11 @@ export function setFacebookApplicationQuerySchemes(
   };
 }
 
-export const withUserTrackingPermission: ConfigPlugin<{
-  iosUserTrackingPermission?: string | false;
-} | void> = (config, { iosUserTrackingPermission } = {}) => {
+export const withUserTrackingPermission: ConfigPlugin<
+  {
+    iosUserTrackingPermission?: string | false;
+  } | void
+> = (config, {iosUserTrackingPermission} = {}) => {
   if (iosUserTrackingPermission === false) {
     return config;
   }

--- a/plugin/src/withSKAdNetworkIdentifiers.ts
+++ b/plugin/src/withSKAdNetworkIdentifiers.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin } from '@expo/config-plugins';
+import {ConfigPlugin} from '@expo/config-plugins';
 
 /**
  * Plugin to add [`SKAdNetworkIdentifier`](https://developer.apple.com/documentation/storekit/skadnetwork/configuring_the_participating_apps)s to the Info.plist safely.
@@ -7,7 +7,10 @@ import { ConfigPlugin } from '@expo/config-plugins';
  * @param config
  * @param props.identifiers array of lowercase string ids to push to the `SKAdNetworkItems` array in the `Info.plist`.
  */
-export const withSKAdNetworkIdentifiers: ConfigPlugin<string[]> = (config, identifiers) => {
+export const withSKAdNetworkIdentifiers: ConfigPlugin<string[]> = (
+  config,
+  identifiers,
+) => {
   if (!config.ios) {
     config.ios = {};
   }
@@ -20,7 +23,7 @@ export const withSKAdNetworkIdentifiers: ConfigPlugin<string[]> = (config, ident
 
   // Get ids
   let existingIds = config.ios.infoPlist.SKAdNetworkItems.map(
-    (item: any) => item?.SKAdNetworkIdentifier ?? null
+    (item: any) => item?.SKAdNetworkIdentifier ?? null,
   ).filter(Boolean) as string[];
   // remove duplicates
   existingIds = [...new Set(existingIds)];

--- a/src/models/FBSDKCallback.ts
+++ b/src/models/FBSDKCallback.ts
@@ -1,3 +1,3 @@
 export type RNFBSDKCallback = {
-  isCancelled: boolean,
+  isCancelled: boolean;
 };


### PR DESCRIPTION
This PR:
- Removes the [require pragma](https://prettier.io/docs/en/options.html#require-pragma) option from the prettier config. Only one file needed formatting, so fully transitioning to prettier here should not hurt.
- Includes the jest and plugin folders in the prettier config. Let me know what you think.