### PR TITLE
fix(expo, ios)!: iosUserTrackingPermission no longer added by default in Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ The plugin provides props for extra customization. Every time you change the pro
 - `appID` (_string_): Facebook Application ID.
 - `displayName` (_string_): Application Name.
 - `clientToken` (_string_): Client Token.
-- `iosUserTrackingPermission` (_string_): iOS User Tracking Permission. Defaults `This identifier will be used to deliver personalized ads to you.`.
+- `iosUserTrackingPermission` (_string_): iOS User Tracking Permission.
 - `advertiserIDCollectionEnabled` (_boolean_): Enable advertiser ID collection. Default `false`.
 - `autoLogAppEventsEnabled` (_boolean_): Default `false`.
 - `isAutoInitEnabled` (_boolean_): Default `false`.
@@ -740,7 +740,8 @@ The plugin provides props for extra customization. Every time you change the pro
           "displayName": "RN SDK Demo",
           "advertiserIDCollectionEnabled": false,
           "autoLogAppEventsEnabled": false,
-          "isAutoInitEnabled": true
+          "isAutoInitEnabled": true,
+          "iosUserTrackingPermission": "This identifier will be used to deliver personalized ads to you."
         }
       ]
     ]

--- a/plugin/build/config.d.ts
+++ b/plugin/build/config.d.ts
@@ -28,8 +28,6 @@ export declare type ConfigProps = {
     advertiserIDCollectionEnabled?: boolean;
     /**
      * Sets the iOS `NSUserTrackingUsageDescription` permission message in the `Info.plist`.
-     * Passing `false` will skip adding the permission.
-     * @default 'This identifier will be used to deliver personalized ads to you.'
      */
     iosUserTrackingPermission?: string | false;
 };

--- a/plugin/build/withFacebookIOS.js
+++ b/plugin/build/withFacebookIOS.js
@@ -6,7 +6,6 @@ const config_plugins_1 = require("@expo/config-plugins");
 const { Scheme } = config_plugins_1.IOSConfig;
 const { appendScheme } = Scheme;
 const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
-const USER_TRACKING = 'This identifier will be used to deliver personalized ads to you.';
 const withFacebookIOS = (config, props) => {
     return (0, config_plugins_1.withInfoPlist)(config, (config) => {
         config.modResults = setFacebookConfig(props, config.modResults);
@@ -148,7 +147,7 @@ function setFacebookApplicationQuerySchemes(config, infoPlist) {
 }
 exports.setFacebookApplicationQuerySchemes = setFacebookApplicationQuerySchemes;
 const withUserTrackingPermission = (config, { iosUserTrackingPermission } = {}) => {
-    if (iosUserTrackingPermission === false) {
+    if (!iosUserTrackingPermission) {
         return config;
     }
     if (!config.ios) {
@@ -159,8 +158,7 @@ const withUserTrackingPermission = (config, { iosUserTrackingPermission } = {}) 
     }
     config.ios.infoPlist.NSUserTrackingUsageDescription =
         iosUserTrackingPermission ||
-            config.ios.infoPlist.NSUserTrackingUsageDescription ||
-            USER_TRACKING;
+            config.ios.infoPlist.NSUserTrackingUsageDescription;
     return config;
 };
 exports.withUserTrackingPermission = withUserTrackingPermission;

--- a/plugin/src/__tests__/withUserTrackingPermission-test.ts
+++ b/plugin/src/__tests__/withUserTrackingPermission-test.ts
@@ -30,18 +30,12 @@ describe(withUserTrackingPermission, () => {
     });
   });
 
-  it(`adds default user tracking description`, () => {
+  it(`does not add user tracking description by default`, () => {
     expect(
       withUserTrackingPermission({name: 'foo', slug: 'bar'}, {}),
     ).toStrictEqual({
       name: 'foo',
       slug: 'bar',
-      ios: {
-        infoPlist: {
-          NSUserTrackingUsageDescription:
-            'This identifier will be used to deliver personalized ads to you.',
-        },
-      },
     });
   });
 

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -40,10 +40,8 @@ export type ConfigProps = {
 
   /**
    * Sets the iOS `NSUserTrackingUsageDescription` permission message in the `Info.plist`.
-   * Passing `false` will skip adding the permission.
-   * @default 'This identifier will be used to deliver personalized ads to you.'
    */
-  iosUserTrackingPermission?: string | false;
+  iosUserTrackingPermission?: string;
 };
 
 export function getMergePropsWithConfig(

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -41,7 +41,7 @@ export type ConfigProps = {
   /**
    * Sets the iOS `NSUserTrackingUsageDescription` permission message in the `Info.plist`.
    */
-  iosUserTrackingPermission?: string;
+  iosUserTrackingPermission?: string | false;
 };
 
 export function getMergePropsWithConfig(

--- a/plugin/src/withFacebookIOS.ts
+++ b/plugin/src/withFacebookIOS.ts
@@ -199,7 +199,7 @@ export function setFacebookApplicationQuerySchemes(
 
 export const withUserTrackingPermission: ConfigPlugin<
   {
-    iosUserTrackingPermission?: string;
+    iosUserTrackingPermission?: string | false;
   } | void
 > = (config, {iosUserTrackingPermission} = {}) => {
   if (!iosUserTrackingPermission) {

--- a/plugin/src/withFacebookIOS.ts
+++ b/plugin/src/withFacebookIOS.ts
@@ -20,9 +20,6 @@ const {appendScheme} = Scheme;
 
 const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
 
-const USER_TRACKING =
-  'This identifier will be used to deliver personalized ads to you.';
-
 export const withFacebookIOS: ConfigPlugin<ConfigProps> = (config, props) => {
   return withInfoPlist(config, (config) => {
     config.modResults = setFacebookConfig(props, config.modResults);
@@ -202,10 +199,10 @@ export function setFacebookApplicationQuerySchemes(
 
 export const withUserTrackingPermission: ConfigPlugin<
   {
-    iosUserTrackingPermission?: string | false;
+    iosUserTrackingPermission?: string;
   } | void
 > = (config, {iosUserTrackingPermission} = {}) => {
-  if (iosUserTrackingPermission === false) {
+  if (!iosUserTrackingPermission) {
     return config;
   }
 
@@ -217,8 +214,7 @@ export const withUserTrackingPermission: ConfigPlugin<
   }
   config.ios.infoPlist.NSUserTrackingUsageDescription =
     iosUserTrackingPermission ||
-    config.ios.infoPlist.NSUserTrackingUsageDescription ||
-    USER_TRACKING;
+    config.ios.infoPlist.NSUserTrackingUsageDescription;
 
   return config;
 };


### PR DESCRIPTION
Fixes #272

Test Plan: `yarn test`

Please give any feedback whether it is better to have default `NSUserTrackingUsageDescription` or make it optional.