### PR TITLE
feat(ios, sdk): bump facebook-ios-sdk to 14.1.0

### DIFF
--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -14,18 +14,18 @@ Pod::Spec.new do |s|
   s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 14.0.0'
+    ss.dependency     'FBSDKCoreKit', '~> 14.1.0'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 14.0.0'
+    ss.dependency     'FBSDKLoginKit', '~> 14.1.0'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 14.0.0'
-    ss.dependency     'FBSDKGamingServicesKit', '~> 14.0.0'
+    ss.dependency     'FBSDKShareKit', '~> 14.1.0'
+    ss.dependency     'FBSDKGamingServicesKit', '~> 14.1.0'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
Facebook is asking for the sdk to be updated. This ups the fb-sdk for ios to 14.1.0.

Fixes #294

