### PR TITLE
docs(ios, AEM): AEM setup requires a reporter parameter in API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ The DeepLink URL from the re-engagement ads should be passed to the AEM Kit even
 
 // apply codes below to `application:openURL:options:` 
 // in `AppDelegate.m` or `SceneDelegate.m`
-[FBAEMReporter configureWithNetworker:nil appID:{app-id}];
+[FBAEMReporter configureWithNetworker:nil appID:@"{app-id}" reporter nil]; // Replace {app-id} with your Facebook App id
 [FBAEMReporter enable];
 [FBAEMReporter handleURL:url];
 ```


### PR DESCRIPTION
I corrected the configuration of FBAEMReporter for iOS as it needs a reporter parameter.
