### PR TITLE
feat(expo): bump ios deployment target from 12.4 to 13

### DIFF
--- a/RNFBSDKExample/ios/Podfile
+++ b/RNFBSDKExample/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '12.4'
+platform :ios, '13.0'
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'RNFBSDKExample' do

--- a/RNFBSDKExample/ios/Podfile-e
+++ b/RNFBSDKExample/ios/Podfile-e
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '12.4'
+platform :ios, '13.0'
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'RNFBSDKExample' do

--- a/RNFBSDKExample/ios/RNFBSDKExample.xcodeproj/project.pbxproj
+++ b/RNFBSDKExample/ios/RNFBSDKExample.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = RNFBSDKExampleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -465,7 +465,7 @@
 				COPY_PHASE_STRIP = NO;
 				EXCLUDED_ARCHS = i386;
 				INFOPLIST_FILE = RNFBSDKExampleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -586,7 +586,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -651,7 +651,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/ios/ExpoAdapterFBSDKNext.podspec
+++ b/ios/ExpoAdapterFBSDKNext.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '12.0'
+  s.platform       = :ios, '13.0'
   s.swift_version  = '5.4'
   s.source         = { :git => 'https://github.com/thebergamo/react-native-fbsdk-next.git', :tag => "v#{package['version']}" }
   s.static_framework = true

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license       = package['license']
   s.homepage      = package['homepage']
   s.source        = { :git => 'https://github.com/thebergamo/react-native-fbsdk-next.git', :tag => "v#{package['version']}" }
-  s.platforms     = { :ios => "12.0", :tvos => "12.0" }
+  s.platforms     = { :ios => "13.0", :tvos => "13.0" }
   s.dependency      'React-Core'
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
Bumped deployment target version from 12.4 to 13.0 to support Expo SDK 47 which dropped support for iOS 12

Overwhelming majority of iOS devices are on iOS 14 or 15 (see Apple's public usage data for reference) https://developer.apple.com/support/app-store/

Test Plan:

`yarn test`
