### PR TITLE
feat(Expo): bump Expo Adapters version from 12.0 to 13.0

### DIFF
--- a/ios/ExpoAdapterFBSDKNext.podspec
+++ b/ios/ExpoAdapterFBSDKNext.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '12.0'
+  s.platform       = :ios, '13.0'
   s.swift_version  = '5.4'
   s.source         = { :git => 'https://github.com/thebergamo/react-native-fbsdk-next.git', :tag => "v#{package['version']}" }
   s.static_framework = true


### PR DESCRIPTION
Bumping expo adapter version for a minimum iOS version of 13.0 for supporting expo sdk 47 

Fixes #346