### PR TITLE
fix: type definition of AppEvents and AppEventParams in FBAppEventsLogger.ts

### DIFF
--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -134,7 +134,10 @@ export type AppEventParam = {
   ValueYes: string;
 };
 
-const {AppEvents, AppEventParams} = AppEventsLogger?.getConstants() || {};
+const {AppEvents, AppEventParams} = (AppEventsLogger?.getConstants() || {}) as {
+  AppEvents: AppEvent;
+  AppEventParams: AppEventParam;
+};
 
 export default {
   /**


### PR DESCRIPTION
The compiled version of present `FBAppEventsLogger.d.ts` looks like this:
```
...
    /**
     * Predefined event names for logging events common to many apps.
     */
    AppEvents: any;
    /**
     *  Predefined event name parameters for common additional information to accompany events logged through the `logEvent`.
     */
    AppEventParams: any;
};
...
```

As you can see, `AppEvents` and `AppEventParams` are typed as any. This PR attempts to fix this issue.