### PR TITLE
docs: Add expo facebook migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,31 @@ if (status === 'granted') {
 }
 ```
 
+## Migrating from expo-facebook to react-native-fbsdk-next
+The [expo-facebook](https://github.com/expo/expo-facebook) module was deprecated in Expo SDK 45 and removed in Expo SDK 46. The following feature parity table lists the `expo-facebook` API functions and their `react-native-fbsdk-native` counterparts, where available:
+
+| expo-facebook | Supported | react-native-fbsdk-next |
+| --- | --- | --- |
+| [flushAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#flushasync) | ✅ | AppEventsLogger.flush() |
+| [getAdvertiserIDAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#getadvertiseridasync) | ❌ | Not supported |
+| [getAnonymousIDAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#getanonymousidasync) | ✅ | AppEventsLogger.getAnonymousID() |
+| [getAttributionIDAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#getattributionidasync) | ✅ | AppEventsLogger.getAttributionID() |
+| [getAuthenticationCredentialAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#getauthenticationcredentialasync) | ✅ | AccessToken.accessToken |
+| [getPermissionsAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#getpermissionsasync) | ❌ | Not supported |
+| [getUserIDAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#getuseridasync) | ✅ | AppEventsLogger.getUserId() |
+| [initializeAsync(optionsOrAppId, appName)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#initializeasyncoptionsorappid-appname) | ✅ | Settings.setAppID($appId); Settings.setAppName($appName); Settings.setGraphAPIVersion($version); Settings.setAutoLogAppEventsEnabled($autoLogAppEvents); <br/> Settings.initializeSDK() |
+| [logEventAsync(eventName, parameters)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#logeventasynceventname-parameters) | ✅ | AppEventsLogger.logEvent(eventName, parameters) |
+| [logInWithReadPermissionsAsync(options)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#loginwithreadpermissionsasyncoptions) | ✅ | LoginManager.logInWithPermissions(permissions) |
+| [logOutAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#logoutasync)  | ✅ | LoginManager.logOut() |
+| [logPurchaseAsync(purchaseAmount, currencyCode, parameters)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#logpurchaseasyncpurchaseamount-currencycode-parameters) | ✅ | AppEventsLogger.logPurchase(purchaseAmount, currency, parameters) |
+| [logPushNotificationOpenAsync(campaign)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#logpushnotificationopenasynccampaign) | ✅ | AppEventsLogger.logPushNotificationOpen(payload) |
+| [requestPermissionsAsync()](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#requestpermissionsasync) | ❌ | Not supported |
+| [setAdvertiserIDCollectionEnabledAsync(enabled)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#setadvertiseridcollectionenabledasyncenabled) | ✅ | Settings.setAdvertiserIDCollectionEnabled(enabled) |
+| [setAdvertiserTrackingEnabledAsync(enabled)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#setadvertisertrackingenabledasyncenabled) | ✅ | Settings.setAdvertiserTrackingEnabled(enabled) |
+| [setAutoLogAppEventsEnabledAsync(enabled)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#setautologappeventsenabledasyncenabled) | ✅ | Settings.setAutoLogAppEventsEnabled(enabled) |
+| [setUserDataAsync(userData)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#setuserdataasyncuserdata) | ✅ | AppEventsLogger.setUserData(userData) |
+| [setUserIDAsync(userID)](https://docs.expo.dev/versions/v45.0.0/sdk/facebook/#setuseridasyncuserid) | ✅ | AppEventsLogger.setUserID(userID) |
+
 ## Example app
 To run the example app, you'll first need to setup the environment:
 ```

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
@@ -63,4 +63,24 @@ public class FBSettingsModule extends BaseJavaModule {
     public static void setAppID(String appID) {
         FacebookSdk.setApplicationId(appID);
     }
+
+    @ReactMethod
+    public static void setAppName(String displayName) {
+        FacebookSdk.setApplicationName(displayName);
+    }
+
+    @ReactMethod
+    public static void setGraphAPIVersion(String version) {
+        FacebookSdk.setGraphApiVersion(version);
+    }
+
+    @ReactMethod
+    public static void setAutoLogAppEventsEnabled(Boolean enabled) {
+        FacebookSdk.setAutoLogAppEventsEnabled(enabled);
+    }
+
+    @ReactMethod
+    public static void setAdvertiserIDCollectionEnabled(Boolean enabled) {
+        FacebookSdk.setAdvertiserIDCollectionEnabled(enabled);
+    }
 }

--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -29,7 +29,7 @@ RCT_EXPORT_METHOD(getAdvertiserTrackingEnabled:(RCTPromiseResolveBlock)resolve r
 
 RCT_EXPORT_METHOD(setAdvertiserTrackingEnabled:(BOOL)ATE resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-  FBSDKSettings.sharedSettings.advertiserTrackingEnabled = ATE;
+  [FBSDKSettings.sharedSettings setAdvertiserTrackingEnabled:ATE];
   resolve(@(true)); // true means successfully changed
 }
 
@@ -51,6 +51,25 @@ RCT_EXPORT_METHOD(initializeSDK)
 RCT_EXPORT_METHOD(setAppID:(NSString *)appID)
 {
   [FBSDKSettings.sharedSettings setAppID:appID];
+}
+
+RCT_EXPORT_METHOD(setAppName:(NSString *)displayName)
+{
+  [FBSDKSettings.sharedSettings setDisplayName:displayName];
+}
+
+RCT_EXPORT_METHOD(setGraphAPIVersion:(NSString *)version)
+{
+  [FBSDKSettings.sharedSettings setGraphAPIVersion:version];
+}
+
+RCT_EXPORT_METHOD(setAutoLogAppEventsEnabled:(BOOL)enabled)
+{
+  [FBSDKSettings.sharedSettings setAutoLogAppEventsEnabled:enabled];
+}
+RCT_EXPORT_METHOD(setAdvertiserIDCollectionEnabled:(BOOL)enabled resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
+{
+  [FBSDKSettings.sharedSettings setAdvertiserIDCollectionEnabled:enabled];
 }
 
 @end

--- a/src/FBSettings.ts
+++ b/src/FBSettings.ts
@@ -7,7 +7,7 @@
  *
  * @format
  */
-import {isDefined, isString} from './util/validate';
+import {isDefined, isString, isValidGraphAPIVersion} from './util/validate';
 import {Platform, NativeModules} from 'react-native';
 
 const Settings = NativeModules.FBSettings;
@@ -63,5 +63,45 @@ export default {
       throw new Error("setAppID expected 'appID' to be a non empty string");
     }
     Settings.setAppID(appID);
+  },
+  /**
+   * Sets the Facebook application name for the current app.
+   */
+  setAppName(appName: string) {
+    if (!isDefined(appName) || !isString(appName) || appName.length === 0) {
+      throw new Error("setAppName expected 'appName' to be a non empty string");
+    }
+    Settings.setAppName(appName);
+  },
+  /**
+   * Sets the Graph API version to use when making Graph requests.
+   */
+  setGraphAPIVersion(version: string) {
+    if (
+      !isDefined(version) ||
+      !isString(version) ||
+      version.length === 0 ||
+      !isValidGraphAPIVersion(version)
+    ) {
+      throw new Error(
+        "setGraphAPIVersion expected 'version' to be a non empty string",
+      );
+    }
+    Settings.setGraphAPIVersion(version);
+  },
+  /**
+   * Sets whether Facebook SDK should log app events. App events involve eg. app installs,
+   * app launches etc.
+   */
+  setAutoLogAppEventsEnabled(enabled: boolean) {
+    Settings.setAutoLogAppEventsEnabled(enabled);
+  },
+  /**
+   * Whether the Facebook SDK should collect advertiser ID properties, like the Apple IDFA
+   * and Android Advertising ID, automatically. Advertiser IDs let you identify and target
+   * specific customers.
+   */
+  setAdvertiserIDCollectionEnabled(enabled: boolean) {
+    Settings.setAdvertiserIDCollectionEnabled(enabled);
   },
 };

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -145,6 +145,14 @@ export function isValidUrl(url: string) {
 }
 
 /**
+ * Matches Graph API versions of the form v2.7
+ */
+const IS_VALID_GRAPH_API_VERSION = /^(v([0-9]+).([0-9]+))/;
+export function isValidGraphAPIVersion(version: string) {
+  return IS_VALID_GRAPH_API_VERSION.test(version);
+}
+
+/**
  * Array includes
  */
 export function isOneOf(value: unknown, oneOf: unknown[] = []) {


### PR DESCRIPTION
### Description
The [expo-facebook](https://github.com/expo/expo-facebook) module was deprecated in Expo SDK 45 and removed in Expo SDK 46. This PR aims to provide developers migrating from `expo-facebook` to `react-native-fbsdk-next` with some documentation to ease the transition.

Also adds support for the following Facebook SDK methods:
* **setAppName**
* **setGraphAPIVersion**
* **setAutoLogAppEventsEnabled**
* **setAdvertiserIDCollectionEnabled**

Fixes #142 

### Test Plan
Update the App.js

```js
Settings.setAppID("<your-app-id>");
Settings.setAppName("<your-app-name>");
Settings.setGraphAPIVersion("<graph-api-version>"); // e.g. "v14.0"
Settings.setAutoLogAppEventsEnabled(true);
Settings.initializeSDK()
```

All changes were verified by running the `yarn example:android` & `yarn example:ios` scripts.