### PR TITLE
refactor(plugin): stop merging config plugin props and expo config

### DIFF
--- a/plugin/build/config.d.ts
+++ b/plugin/build/config.d.ts
@@ -1,5 +1,3 @@
-import { ExpoConfig } from '@expo/config-types';
-export declare type ExpoConfigFacebook = Pick<ExpoConfig, 'facebookScheme' | 'facebookAdvertiserIDCollectionEnabled' | 'facebookAppId' | 'facebookAutoInitEnabled' | 'facebookAutoLogAppEventsEnabled' | 'facebookDisplayName'>;
 export declare type ConfigProps = {
     /**
      * Used for all Facebook libraries. Set up your Facebook App ID at https://developers.facebook.com.
@@ -31,7 +29,7 @@ export declare type ConfigProps = {
      */
     iosUserTrackingPermission?: string | false;
 };
-export declare function getMergePropsWithConfig(config: ExpoConfigFacebook, props: ConfigProps | void): ConfigProps;
+export declare function getConfigProps(props: ConfigProps | void): ConfigProps;
 export declare function getFacebookAppId(config: ConfigProps): string | null;
 export declare function getFacebookClientToken(config: ConfigProps): string | null;
 export declare function getFacebookScheme(config: ConfigProps): string | null;

--- a/plugin/build/config.js
+++ b/plugin/build/config.js
@@ -1,9 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getFacebookAdvertiserIDCollection = exports.getFacebookAutoLogAppEvents = exports.getFacebookAutoInitEnabled = exports.getFacebookDisplayName = exports.getFacebookScheme = exports.getFacebookClientToken = exports.getFacebookAppId = exports.getMergePropsWithConfig = void 0;
-function getMergePropsWithConfig(config, props) {
-    const { facebookAppId, facebookDisplayName, facebookScheme, facebookAutoInitEnabled, facebookAutoLogAppEventsEnabled, facebookAdvertiserIDCollectionEnabled, } = config;
-    const { appID = facebookAppId, clientToken, displayName = facebookDisplayName, scheme = facebookScheme !== null && facebookScheme !== void 0 ? facebookScheme : (appID ? `fb${appID}` : undefined), isAutoInitEnabled = facebookAutoInitEnabled !== null && facebookAutoInitEnabled !== void 0 ? facebookAutoInitEnabled : false, autoLogAppEventsEnabled = facebookAutoLogAppEventsEnabled !== null && facebookAutoLogAppEventsEnabled !== void 0 ? facebookAutoLogAppEventsEnabled : false, advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled !== null && facebookAdvertiserIDCollectionEnabled !== void 0 ? facebookAdvertiserIDCollectionEnabled : false, iosUserTrackingPermission, } = (props !== null && props !== void 0 ? props : {});
+exports.getFacebookAdvertiserIDCollection = exports.getFacebookAutoLogAppEvents = exports.getFacebookAutoInitEnabled = exports.getFacebookDisplayName = exports.getFacebookScheme = exports.getFacebookClientToken = exports.getFacebookAppId = exports.getConfigProps = void 0;
+function getConfigProps(props) {
+    const { appID, clientToken, displayName, scheme = appID ? `fb${appID}` : undefined, isAutoInitEnabled = false, autoLogAppEventsEnabled = false, advertiserIDCollectionEnabled = false, iosUserTrackingPermission = false, } = (props !== null && props !== void 0 ? props : {});
     return {
         appID,
         clientToken,
@@ -15,7 +14,7 @@ function getMergePropsWithConfig(config, props) {
         iosUserTrackingPermission,
     };
 }
-exports.getMergePropsWithConfig = getMergePropsWithConfig;
+exports.getConfigProps = getConfigProps;
 function getFacebookAppId(config) {
     var _a;
     return (_a = config.appID) !== null && _a !== void 0 ? _a : null;

--- a/plugin/build/withFacebook.js
+++ b/plugin/build/withFacebook.js
@@ -8,7 +8,7 @@ const config_plugins_1 = require("@expo/config-plugins");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('react-native-fbsdk-next/package.json');
 const withFacebook = (config, props) => {
-    const newProps = (0, config_1.getMergePropsWithConfig)(config, props);
+    const newProps = (0, config_1.getConfigProps)(props);
     if (!newProps.appID) {
         throw new Error('missing appID in the plugin properties');
     }

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -1,15 +1,3 @@
-import {ExpoConfig} from '@expo/config-types';
-
-export type ExpoConfigFacebook = Pick<
-  ExpoConfig,
-  | 'facebookScheme'
-  | 'facebookAdvertiserIDCollectionEnabled'
-  | 'facebookAppId'
-  | 'facebookAutoInitEnabled'
-  | 'facebookAutoLogAppEventsEnabled'
-  | 'facebookDisplayName'
->;
-
 export type ConfigProps = {
   /**
    * Used for all Facebook libraries. Set up your Facebook App ID at https://developers.facebook.com.
@@ -44,28 +32,18 @@ export type ConfigProps = {
   iosUserTrackingPermission?: string | false;
 };
 
-export function getMergePropsWithConfig(
-  config: ExpoConfigFacebook,
+export function getConfigProps(
   props: ConfigProps | void,
 ): ConfigProps {
   const {
-    facebookAppId,
-    facebookDisplayName,
-    facebookScheme,
-    facebookAutoInitEnabled,
-    facebookAutoLogAppEventsEnabled,
-    facebookAdvertiserIDCollectionEnabled,
-  } = config;
-  const {
-    appID = facebookAppId,
+    appID,
     clientToken,
-    displayName = facebookDisplayName,
-    scheme = facebookScheme ?? (appID ? `fb${appID}` : undefined),
-    isAutoInitEnabled = facebookAutoInitEnabled ?? false,
-    autoLogAppEventsEnabled = facebookAutoLogAppEventsEnabled ?? false,
-    advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled ??
-      false,
-    iosUserTrackingPermission,
+    displayName,
+    scheme = appID ? `fb${appID}` : undefined,
+    isAutoInitEnabled = false,
+    autoLogAppEventsEnabled = false,
+    advertiserIDCollectionEnabled = false,
+    iosUserTrackingPermission = false,
   } = (props ?? {}) as ConfigProps;
 
   return {

--- a/plugin/src/withFacebook.ts
+++ b/plugin/src/withFacebook.ts
@@ -1,4 +1,4 @@
-import {ConfigProps, getMergePropsWithConfig} from './config';
+import {ConfigProps, getConfigProps} from './config';
 import {
   withAndroidPermissions,
   withFacebookAppIdString,
@@ -12,7 +12,7 @@ import {ConfigPlugin, createRunOncePlugin} from '@expo/config-plugins';
 const pkg = require('react-native-fbsdk-next/package.json');
 
 const withFacebook: ConfigPlugin<ConfigProps | void> = (config, props) => {
-  const newProps = getMergePropsWithConfig(config, props);
+  const newProps = getConfigProps(props);
   if (!newProps.appID) {
     throw new Error('missing appID in the plugin properties');
   }


### PR DESCRIPTION
My name is Cedric, and I work for Expo. We are currently deprecating the facebook fields from the Expo config. The fields listed below won't be included in the upcoming SDK 48. This PR removes the part that uses these deprecated fields. And instead, fully rely on the config plugin options.

<details><summary>Deprecated fields from Expo config</summary>

- `facebookAppId`
- `facebookAutoInitEnabled`
- `facebookAutoLogAppEventsEnabled`
- `facebookAdvertiserIDCollectionEnabled`
- `facebookDisplayName`
- `facebookScheme`

</details>

Test Plan:

- `$ yarn create expo-app ./test`
- `$ cd ./test`
- `$ yarn expo install react-native-fbsdk-next`
- _Add the config plugin and properties to **app.json** ([see readme](https://github.com/thebergamo/react-native-fbsdk-next#expo-installation))_
- `$ yarn expo prebuild`
- Native files should have the right properties.
