### PR TITLE
feat(EventLogger): add type for AppEvents and AppEventsParams

### DIFF
--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -134,7 +134,11 @@ export type AppEventParam = {
   ValueYes: string;
 };
 
-const {AppEvents, AppEventParams} = AppEventsLogger?.getConstants() || {};
+const {
+  AppEvents,
+  AppEventParams,
+}: {AppEvents: AppEvent; AppEventParams: AppEventParam} =
+  AppEventsLogger?.getConstants() || {};
 
 export default {
   /**


### PR DESCRIPTION
Adding type to AppEvents and AppEventsParams to be able to see what types are available to be used following AppEventsLogger.AppEvents, making it easier when creating a log.
