### PR TITLE
feat: add setClientToken method

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
@@ -8,11 +8,15 @@
 
 package com.facebook.reactnative.androidsdk;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.FacebookSdk;
+import com.facebook.react.bridge.BaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.module.annotations.ReactModule;
+import java.util.ArrayList;
 import java.util.List;
-
 
 /**
  * This is a {@link NativeModule} that allows JS to use SDK settings in Facebook Android SDK.

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
@@ -8,15 +8,11 @@
 
 package com.facebook.reactnative.androidsdk;
 
-import androidx.annotation.Nullable;
-
 import com.facebook.FacebookSdk;
-import com.facebook.react.bridge.BaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.module.annotations.ReactModule;
-import java.util.ArrayList;
 import java.util.List;
+
 
 /**
  * This is a {@link NativeModule} that allows JS to use SDK settings in Facebook Android SDK.
@@ -62,6 +58,15 @@ public class FBSettingsModule extends BaseJavaModule {
     @ReactMethod
     public static void setAppID(String appID) {
         FacebookSdk.setApplicationId(appID);
+    }
+
+    /**
+     * Set client token
+     * @param clientToken client token
+     */
+    @ReactMethod
+    public static void setClientToken(String clientToken) {
+        FacebookSdk.setClientToken(clientToken);
     }
 
     @ReactMethod

--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -53,6 +53,11 @@ RCT_EXPORT_METHOD(setAppID:(NSString *)appID)
   [FBSDKSettings.sharedSettings setAppID:appID];
 }
 
+RCT_EXPORT_METHOD(setClientToken:(NSString *)clientToken)
+{
+  [FBSDKSettings.sharedSettings setClientToken:clientToken];
+}
+
 RCT_EXPORT_METHOD(setAppName:(NSString *)displayName)
 {
   [FBSDKSettings.sharedSettings setDisplayName:displayName];

--- a/src/FBSettings.ts
+++ b/src/FBSettings.ts
@@ -65,6 +65,15 @@ export default {
     Settings.setAppID(appID);
   },
   /**
+   * Set clientToken
+   */
+  setApsetClientTokenpID(clientToken: string) {
+    if (!isDefined(clientToken) || !isString(clientToken) || clientToken.length === 0) {
+      throw new Error("setClientToken expected 'clientToken' to be a non empty string");
+    }
+    Settings.setClientToken(clientToken);
+  },
+  /**
    * Sets the Facebook application name for the current app.
    */
   setAppName(appName: string) {

--- a/src/FBSettings.ts
+++ b/src/FBSettings.ts
@@ -67,7 +67,7 @@ export default {
   /**
    * Set clientToken
    */
-  setApsetClientTokenpID(clientToken: string) {
+  setClientToken(clientToken: string) {
     if (!isDefined(clientToken) || !isString(clientToken) || clientToken.length === 0) {
       throw new Error("setClientToken expected 'clientToken' to be a non empty string");
     }

--- a/src/FBSettings.ts
+++ b/src/FBSettings.ts
@@ -68,8 +68,14 @@ export default {
    * Set clientToken
    */
   setClientToken(clientToken: string) {
-    if (!isDefined(clientToken) || !isString(clientToken) || clientToken.length === 0) {
-      throw new Error("setClientToken expected 'clientToken' to be a non empty string");
+    if (
+      !isDefined(clientToken) ||
+      !isString(clientToken) ||
+      clientToken.length === 0
+    ) {
+      throw new Error(
+        "setClientToken expected 'clientToken' to be a non empty string",
+      );
     }
     Settings.setClientToken(clientToken);
   },


### PR DESCRIPTION
setClientToken is available on the Facebook SDK: 
- iOS: https://developers.facebook.com/docs/reference/ios/current/constants/FBSDKSettings
- Android: https://developers.facebook.com/docs/reference/android/current/class/FacebookSdk

Adding functions to handle setClientToken inapp