### PR TITLE
feat(sdks): Upgrade FBSDK to 16.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,12 @@ Follow ***steps 2, 3 and 4*** in the [Getting Started Guide](https://developers.
 
 **NOTE:** The above link (Step 3 and 4) contains Swift code instead of Objective-C which is inconvenient since `react-native` ecosystem still relies
    on Objective-C. To make it work in Objective-C you need to do the following in `/ios/PROJECT/AppDelegate.m`:
-   1. Add `#import <FBSDKCoreKit/FBSDKCoreKit-swift.h>`
+   1. Add
+   ```objc
+   #import <AuthenticationServices/AuthenticationServices.h>
+   #import <SafariServices/SafariServices.h>
+   #import <FBSDKCoreKit/FBSDKCoreKit-swift.h>
+   ```
    2. Inside `didFinishLaunchingWithOptions`, add the following:
       ```objc
          [[FBSDKApplicationDelegate sharedInstance] application:application
@@ -153,6 +158,8 @@ Follow ***steps 2, 3 and 4*** in the [Getting Started Guide](https://developers.
 The `AppDelegate.m` file can only have one method for `openUrl`. If you're also using `RCTLinkingManager` to handle deep links, you should handle both results in your `openUrl` method.
 
 ```objc
+#import <AuthenticationServices/AuthenticationServices.h> // <- Add This Import
+#import <SafariServices/SafariServices.h> // <- Add This Import
 #import <FBSDKCoreKit/FBSDKCoreKit-swift.h> // <- Add This Import
 #import <React/RCTLinkingManager.h> // <- Add This Import
 
@@ -295,6 +302,8 @@ Settings.initializeSDK();
 If you would like to initialize the Facebook SDK even earlier in startup for iOS, you need to include this code in your AppDelegate.m file now that auto-initialization is removed.
 
 ```objective-c
+#import <AuthenticationServices/AuthenticationServices.h> // <- Add This Import
+#import <SafariServices/SafariServices.h> // <- Add This Import
 #import <FBSDKCoreKit/FBSDKCoreKit-swift.h> // <- Add This Import
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -643,13 +652,13 @@ Add the following code in the system `application:openURL:options:` function fro
 The DeepLink URL from the re-engagement ads should be passed to the AEM Kit even if the app is opened in cold start.
 
 ```objc
-#import <FBAEMKit/FBAEMKit.h>
+#import <FBAEMKit/FBAEMKit-Swift.h>
 
 // apply codes below to `application:openURL:options:` 
 // in `AppDelegate.m` or `SceneDelegate.m`
 [FBAEMReporter configureWithNetworker:nil appID:@"{app-id}" reporter:nil]; // Replace {app-id} with your Facebook App id
 [FBAEMReporter enable];
-[FBAEMReporter handleURL:url];
+[FBAEMReporter handle:url];
 ```
 
 #### **Step 2. Add AEM Logging**

--- a/RNFBSDKExample/ios/Podfile.lock
+++ b/RNFBSDKExample/ios/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBAEMKit (15.0.0):
-    - FBSDKCoreKit_Basics (= 15.0.0)
+  - FBAEMKit (16.1.3):
+    - FBSDKCoreKit_Basics (= 16.1.3)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
     - RCT-Folly (= 2021.07.22.00)
@@ -12,18 +12,18 @@ PODS:
     - React-Core (= 0.72.4)
     - React-jsi (= 0.72.4)
     - ReactCommon/turbomodule/core (= 0.72.4)
-  - FBSDKCoreKit (15.0.0):
-    - FBAEMKit (= 15.0.0)
-    - FBSDKCoreKit_Basics (= 15.0.0)
-  - FBSDKCoreKit_Basics (15.0.0)
-  - FBSDKGamingServicesKit (15.0.0):
-    - FBSDKCoreKit (= 15.0.0)
-    - FBSDKCoreKit_Basics (= 15.0.0)
-    - FBSDKShareKit (= 15.0.0)
-  - FBSDKLoginKit (15.0.0):
-    - FBSDKCoreKit (= 15.0.0)
-  - FBSDKShareKit (15.0.0):
-    - FBSDKCoreKit (= 15.0.0)
+  - FBSDKCoreKit (16.1.3):
+    - FBAEMKit (= 16.1.3)
+    - FBSDKCoreKit_Basics (= 16.1.3)
+  - FBSDKCoreKit_Basics (16.1.3)
+  - FBSDKGamingServicesKit (16.1.3):
+    - FBSDKCoreKit (= 16.1.3)
+    - FBSDKCoreKit_Basics (= 16.1.3)
+    - FBSDKShareKit (= 16.1.3)
+  - FBSDKLoginKit (16.1.3):
+    - FBSDKCoreKit (= 16.1.3)
+  - FBSDKShareKit (16.1.3):
+    - FBSDKCoreKit (= 16.1.3)
   - Flipper (0.182.0):
     - Flipper-Folly (~> 2.6)
   - Flipper-Boost-iOSX (1.76.0.1.11)
@@ -395,14 +395,14 @@ PODS:
     - react-native-fbsdk-next/Login (= 11.3.0)
     - react-native-fbsdk-next/Share (= 11.3.0)
   - react-native-fbsdk-next/Core (11.3.0):
-    - FBSDKCoreKit (~> 15.0.0)
+    - FBSDKCoreKit (~> 16.1.3)
     - React-Core
   - react-native-fbsdk-next/Login (11.3.0):
-    - FBSDKLoginKit (~> 15.0.0)
+    - FBSDKLoginKit (~> 16.1.3)
     - React-Core
   - react-native-fbsdk-next/Share (11.3.0):
-    - FBSDKGamingServicesKit (~> 15.0.0)
-    - FBSDKShareKit (~> 15.0.0)
+    - FBSDKGamingServicesKit (~> 16.1.3)
+    - FBSDKShareKit (~> 16.1.3)
     - React-Core
   - React-NativeModulesApple (0.72.4):
     - hermes-engine
@@ -695,14 +695,14 @@ SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBAEMKit: d8312d8451ead46282adc7f3565ffc4965e3a4a7
+  FBAEMKit: af2972f39bb0f3f7c45998f435b007833c32ffb2
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
-  FBSDKCoreKit: 81879058dd06208c0820fc713d054ca54903e8ba
-  FBSDKCoreKit_Basics: eebc9bb69a0e5d133b92dca53a20716227faa454
-  FBSDKGamingServicesKit: e0766514d64d26a9f846e793c0a44bc4a236723b
-  FBSDKLoginKit: 11995469cd7da16fd4d5245e8d2ec61060479270
-  FBSDKShareKit: 9501792c3024580809f811a8a549868699d9bd32
+  FBSDKCoreKit: 19e2e18b3be578d7a51fed8fdd8c152bef0b9511
+  FBSDKCoreKit_Basics: dd9826ce3c9fd9f8cdf8dbbd0ef0a53e6c0c9e7e
+  FBSDKGamingServicesKit: 791d9b1de6da359e92da3b1ba3459f36b0aa604f
+  FBSDKLoginKit: c395c63a1a6cf4a8a1e6103fd94b8c46329ee81c
+  FBSDKShareKit: de5c291ad414ec07048ab09bae1b1b74b3ed92fe
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -731,7 +731,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-fbsdk-next: 16e652b5f1236492631185c58ec2ae15b029119d
+  react-native-fbsdk-next: 26bdbd50321243451443a1a84d66fa569e097223
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00

--- a/RNFBSDKExample/ios/RNFBSDKExample/AppDelegate.mm
+++ b/RNFBSDKExample/ios/RNFBSDKExample/AppDelegate.mm
@@ -1,5 +1,7 @@
 #import "AppDelegate.h"
 
+#import <AuthenticationServices/AuthenticationServices.h>
+#import <SafariServices/SafariServices.h>
 #import <FBSDKCoreKit/FBSDKCoreKit-swift.h>
 #import <React/RCTLinkingManager.h>
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ repositories {
     google()
 }
 
-def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '15.+')
+def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '16.+')
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/ios/RCTFBSDK/core/RCTFBSDKAEMReporter.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKAEMReporter.m
@@ -7,7 +7,7 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
-#import <FBAEMKit/FBAEMReporter.h>
+#import <FBAEMKit/FBAEMKit-Swift.h>
 
 @interface RCTFBSDKAEMReporter : NSObject <RCTBridgeModule>
 @end

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, './', 'package.json')))
 
-FBSDKVersion = "15.0.0"
+FBSDKVersion = "16.1.3"
 
 Pod::Spec.new do |s|
   s.name          = package['name']

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -69,8 +69,12 @@ rm -f android/app/src/main/AndroidManifest.xml??
 sed -i -e 's/<\/application>/  <meta-data android:name="com.facebook.sdk.ApplicationName" android:value="@string\/app_name"\/>\n    <\/application>/' android/app/src/main/AndroidManifest.xml
 rm -f android/app/src/main/AndroidManifest.xml??
 
-# You probably want to see if Facebook can handle a link, so facebook logins work...
-sed -i -e 's/#import "AppDelegate.h"/#import "AppDelegate.h"\n\n#import <FBSDKCoreKit\/FBSDKCoreKit-swift.h>\n#import <React\/RCTLinkingManager.h>/' ios/RNFBSDKExample/AppDelegate.mm
+# FBSDK requires a few imports, and you probably want to see if Facebook can handle a link, so facebook logins work...
+sed -i -e 's/#import "AppDelegate.h"/#import "AppDelegate.h"\n#import <FBSDKCoreKit\/FBSDKCoreKit-swift.h>\n#import <React\/RCTLinkingManager.h>/' ios/RNFBSDKExample/AppDelegate.mm
+rm -f ios/RNFBSDKExample/AppDelegate.mm??
+sed -i -e 's/#import "AppDelegate.h"/#import "AppDelegate.h"\n#import <SafariServices\/SafariServices.h>/' ios/RNFBSDKExample/AppDelegate.mm
+rm -f ios/RNFBSDKExample/AppDelegate.mm??
+sed -i -e 's/#import "AppDelegate.h"/#import "AppDelegate.h"\n\n#import <AuthenticationServices\/AuthenticationServices.h>/' ios/RNFBSDKExample/AppDelegate.mm
 rm -f ios/RNFBSDKExample/AppDelegate.mm??
 
 sed -i -e 's|@implementation AppDelegate|@implementation AppDelegate\n\n- (BOOL)application:(UIApplication *)app\n            openURL:(NSURL *)url\n            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options\n{\n  if ([[FBSDKApplicationDelegate sharedInstance] application:app openURL:url options:options]) {\n    return YES;\n  }\n\n  if ([RCTLinkingManager application:app openURL:url options:options]) {\n    return YES;\n  }\n  \n  return NO;\n}|' ios/RNFBSDKExample/AppDelegate.mm


### PR DESCRIPTION
Updated Facebook SDK to 16.1.3 which is the current latest

Have tested with building the example app locally and ensuring all tests pass.

Based on PR #417