### PR TITLE
docs(ios): fix 'FBSDKCoreKit/FBSDKCoreKit-swift.h' file not found on case-sensitive filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Follow ***steps 2, 3 and 4*** in the [Getting Started Guide](https://developers.
    ```objc
    #import <AuthenticationServices/AuthenticationServices.h>
    #import <SafariServices/SafariServices.h>
-   #import <FBSDKCoreKit/FBSDKCoreKit-swift.h>
+   #import <FBSDKCoreKit/FBSDKCoreKit-Swift.h>
    ```
    2. Inside `didFinishLaunchingWithOptions`, add the following:
       ```objc
@@ -160,7 +160,7 @@ The `AppDelegate.m` file can only have one method for `openUrl`. If you're also 
 ```objc
 #import <AuthenticationServices/AuthenticationServices.h> // <- Add This Import
 #import <SafariServices/SafariServices.h> // <- Add This Import
-#import <FBSDKCoreKit/FBSDKCoreKit-swift.h> // <- Add This Import
+#import <FBSDKCoreKit/FBSDKCoreKit-Swift.h> // <- Add This Import
 #import <React/RCTLinkingManager.h> // <- Add This Import
 
 - (BOOL)application:(UIApplication *)app
@@ -304,7 +304,7 @@ If you would like to initialize the Facebook SDK even earlier in startup for iOS
 ```objective-c
 #import <AuthenticationServices/AuthenticationServices.h> // <- Add This Import
 #import <SafariServices/SafariServices.h> // <- Add This Import
-#import <FBSDKCoreKit/FBSDKCoreKit-swift.h> // <- Add This Import
+#import <FBSDKCoreKit/FBSDKCoreKit-Swift.h> // <- Add This Import
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/RNFBSDKExample/ios/RNFBSDKExample/AppDelegate.mm
+++ b/RNFBSDKExample/ios/RNFBSDKExample/AppDelegate.mm
@@ -2,7 +2,7 @@
 
 #import <AuthenticationServices/AuthenticationServices.h>
 #import <SafariServices/SafariServices.h>
-#import <FBSDKCoreKit/FBSDKCoreKit-swift.h>
+#import <FBSDKCoreKit/FBSDKCoreKit-Swift.h>
 #import <React/RCTLinkingManager.h>
 
 #import <React/RCTBundleURLProvider.h>

--- a/refresh-example.sh
+++ b/refresh-example.sh
@@ -70,7 +70,7 @@ sed -i -e 's/<\/application>/  <meta-data android:name="com.facebook.sdk.Applica
 rm -f android/app/src/main/AndroidManifest.xml??
 
 # FBSDK requires a few imports, and you probably want to see if Facebook can handle a link, so facebook logins work...
-sed -i -e 's/#import "AppDelegate.h"/#import "AppDelegate.h"\n#import <FBSDKCoreKit\/FBSDKCoreKit-swift.h>\n#import <React\/RCTLinkingManager.h>/' ios/RNFBSDKExample/AppDelegate.mm
+sed -i -e 's/#import "AppDelegate.h"/#import "AppDelegate.h"\n#import <FBSDKCoreKit\/FBSDKCoreKit-Swift.h>\n#import <React\/RCTLinkingManager.h>/' ios/RNFBSDKExample/AppDelegate.mm
 rm -f ios/RNFBSDKExample/AppDelegate.mm??
 sed -i -e 's/#import "AppDelegate.h"/#import "AppDelegate.h"\n#import <SafariServices\/SafariServices.h>/' ios/RNFBSDKExample/AppDelegate.mm
 rm -f ios/RNFBSDKExample/AppDelegate.mm??


### PR DESCRIPTION
This fix the issue for case-sensitive file systems. 
It would have no impact for not case-sensitive user systems.

Build error:

![image](https://github.com/thebergamo/react-native-fbsdk-next/assets/17779660/a4911697-87b1-4cce-af18-5715b3c9e6e2)

