### PR TITLE
fix(android): avoid crash on react-native reload if not initialized

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAccessTokenModule.java
@@ -78,7 +78,9 @@ public class FBAccessTokenModule extends ReactContextBaseJavaModule {
     @Override
     public void onCatalystInstanceDestroy() {
         super.onCatalystInstanceDestroy();
-        accessTokenTracker.stopTracking();
+        if (accessTokenTracker != null) {
+            accessTokenTracker.stopTracking();
+        }
     }
 
     /**


### PR DESCRIPTION

If initialize was called correctly, accessTokenTracker would always be non-null

But just in case the state is not correctly initialized, we can avoid crashing


* Fixes #473 

Test Plan:

Untested. A null-check should be harmless though. @GreenFella will test the new release and report success/failure 