### PR TITLE
feat(Expo): bump Expo Adapters version from 13.0 to 13.4

### DIFF
--- a/ios/ExpoAdapterFBSDKNext.podspec
+++ b/ios/ExpoAdapterFBSDKNext.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '13.4'
   s.swift_version  = '5.4'
   s.source         = { :git => 'https://github.com/thebergamo/react-native-fbsdk-next.git', :tag => "v#{package['version']}" }
   s.static_framework = true


### PR DESCRIPTION
Bumped iOS deployment target to 13.4 to support expo sdk 50