### PR TITLE
feat(android): RN-0.73 and Android Gradle Plugin 8.0 Compatibility Fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.facebook.reactnative.androidsdk"
+    }
 }
 
 repositories {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,5 +18,6 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+    package="com.facebook.reactnative.androidsdk">
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,6 +18,5 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<manifest
-    package="com.facebook.reactnative.androidsdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION

Test Plan:
https://github.com/react-native-community/discussions-and-proposals/issues/671

React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. This will require all the libraries to specify a namespace in their build.gradle file. We added a compatibility layer for libraries that haven't specified a namespace, but please consider updating your libraries nonetheless.

<img width="700" alt="Screenshot 2024-01-20 at 5 46 18 PM" src="https://github.com/thebergamo/react-native-fbsdk-next/assets/15888722/4c3da3f5-cb78-45ba-9510-ce380a589950">

