### PR TITLE
fix(expo): update scheme injection

### DIFF
--- a/plugin/src/__tests__/withFacebookAndroid-test.ts
+++ b/plugin/src/__tests__/withFacebookAndroid-test.ts
@@ -117,9 +117,14 @@ describe('Android facebook config', () => {
     }
 
     const facebookActivity = mainApplication.activity?.filter(
+      (e) => e.$['android:name'] === 'com.facebook.FacebookActivity',
+    );
+    expect(facebookActivity).toHaveLength(1)
+
+    const customTabActivity = mainApplication.activity?.filter(
       (e) => e.$['android:name'] === 'com.facebook.CustomTabActivity',
     );
-    expect(facebookActivity).toHaveLength(1);
+    expect(customTabActivity).toHaveLength(1);
 
     const applicationId = mainApplication['meta-data']?.filter(
       (e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationId',

--- a/plugin/src/withFacebookAndroid.ts
+++ b/plugin/src/withFacebookAndroid.ts
@@ -24,6 +24,7 @@ const {
   removeMetaDataItemFromMainApplication,
 } = AndroidConfig.Manifest;
 
+const FACEBOOK_ACTIVITY = 'com.facebook.FacebookActivity';
 const CUSTOM_TAB_ACTIVITY = 'com.facebook.CustomTabActivity';
 const STRING_FACEBOOK_APP_ID = 'facebook_app_id';
 const STRING_FB_LOGIN_PROTOCOL_SCHEME = 'fb_login_protocol_scheme';
@@ -75,18 +76,33 @@ function buildXMLItem({
   children,
 }: {
   head: Record<string, string>;
-  children?: Record<string, string | any[]>;
+  children?: Record<string, string | unknown[]>;
 }) {
   return {...(children ?? {}), $: head};
 }
 
-function buildAndroidItem(datum: string | Record<string, any>) {
+function buildAndroidItem(datum: string | Record<string, unknown>) {
   const item = typeof datum === 'string' ? {name: datum} : datum;
   const head = prefixAndroidKeys(item);
   return buildXMLItem({head});
 }
 
-function getFacebookSchemeActivity() {
+function getFacebookActivity() {
+  /**
+<activity android:name="com.facebook.FacebookActivity"
+    android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+    android:label="@string/app_name" />
+   */
+  return buildXMLItem({
+    head: prefixAndroidKeys({
+      name: FACEBOOK_ACTIVITY,
+      configChanges: 'keyboard|keyboardHidden|screenLayout|screenSize|orientation',
+      label: '@string/app_name'
+    }),
+  }) as AndroidConfig.Manifest.ManifestActivity;
+}
+
+function getCustomTabActivity() {
   /**
 <activity
     android:name="com.facebook.CustomTabActivity"
@@ -131,7 +147,7 @@ function ensureFacebookActivity({
   if (Array.isArray(mainApplication.activity)) {
     // Remove all Facebook CustomTabActivities first
     mainApplication.activity = mainApplication.activity.filter((activity) => {
-      return activity.$?.['android:name'] !== CUSTOM_TAB_ACTIVITY;
+      return ![FACEBOOK_ACTIVITY, CUSTOM_TAB_ACTIVITY].includes(activity.$?.['android:name']);
     });
   } else {
     mainApplication.activity = [];
@@ -139,7 +155,8 @@ function ensureFacebookActivity({
 
   // If a new scheme is defined, append it to the activity.
   if (scheme) {
-    mainApplication.activity.push(getFacebookSchemeActivity());
+    mainApplication.activity.push(getFacebookActivity())
+    mainApplication.activity.push(getCustomTabActivity());
   }
   return mainApplication;
 }

--- a/plugin/src/withFacebookAndroid.ts
+++ b/plugin/src/withFacebookAndroid.ts
@@ -14,10 +14,6 @@ import {
   withAndroidManifest,
   withStringsXml,
 } from '@expo/config-plugins';
-import {
-  appendScheme,
-  hasScheme,
-} from '@expo/config-plugins/build/android/Scheme';
 
 const {buildResourceItem} = AndroidConfig.Resources;
 const {removeStringItem, setStringItem} = AndroidConfig.Strings;
@@ -218,10 +214,6 @@ export function setFacebookConfig(
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mainApplication = getMainApplicationOrThrow(androidManifest);
-
-  if (scheme && !hasScheme(scheme, androidManifest)) {
-    androidManifest = appendScheme(scheme, androidManifest);
-  }
 
   mainApplication = ensureFacebookActivity({scheme, mainApplication});
 


### PR DESCRIPTION
Currently expo plugin injects scheme into all intent filters causing auto verify to break for deep links. See #329 issue for more info.

The fix is to follow latest instructions for configuring [Facebook Login for Android](https://developers.facebook.com/docs/facebook-login/android/#manifest) essentially removing existing injection of scheme into intent filters and adding `<activity android:name="com.facebook.FacebookActivity" .. />`

Test Plan:
Updated unit test to check that new `<activity android:name="com.facebook.FacebookActivity" .. />` has been added to the manifest.

Fixes #329

What this really does is remove support for Android WebViews as per [Deprecating Facebook Login support on Android WebViews](https://developers.facebook.com/docs/facebook-login/android/deprecating-webviews) which should be fine since we are well beyond Facebook SDK 8.2.0 at this point.