### PR TITLE
feat: add support for new architecture in compatibility mode

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSettingsModule.java
@@ -51,7 +51,7 @@ public class FBSettingsModule extends BaseJavaModule {
      * [FB SDK Best Practices for GDPR Compliance](https://developers.facebook.com/docs/app-events/gdpr-compliance/)
      */
     @ReactMethod
-    public static void initializeSDK() {
+    public void initializeSDK() {
         FacebookSdk.fullyInitialize();
     }
 
@@ -60,7 +60,7 @@ public class FBSettingsModule extends BaseJavaModule {
      * @param appID app id
      */
     @ReactMethod
-    public static void setAppID(String appID) {
+    public void setAppID(String appID) {
         FacebookSdk.setApplicationId(appID);
     }
 
@@ -69,27 +69,27 @@ public class FBSettingsModule extends BaseJavaModule {
      * @param clientToken client token
      */
     @ReactMethod
-    public static void setClientToken(String clientToken) {
+    public void setClientToken(String clientToken) {
         FacebookSdk.setClientToken(clientToken);
     }
 
     @ReactMethod
-    public static void setAppName(String displayName) {
+    public void setAppName(String displayName) {
         FacebookSdk.setApplicationName(displayName);
     }
 
     @ReactMethod
-    public static void setGraphAPIVersion(String version) {
+    public void setGraphAPIVersion(String version) {
         FacebookSdk.setGraphApiVersion(version);
     }
 
     @ReactMethod
-    public static void setAutoLogAppEventsEnabled(Boolean enabled) {
+    public void setAutoLogAppEventsEnabled(Boolean enabled) {
         FacebookSdk.setAutoLogAppEventsEnabled(enabled);
     }
 
     @ReactMethod
-    public static void setAdvertiserIDCollectionEnabled(Boolean enabled) {
+    public void setAdvertiserIDCollectionEnabled(Boolean enabled) {
         FacebookSdk.setAdvertiserIDCollectionEnabled(enabled);
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
@@ -31,7 +31,8 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.events.EventDispatcher;
 
 import java.util.Set;
 
@@ -42,11 +43,13 @@ import java.util.Set;
 public class RCTLoginButton extends LoginButton {
 
     private final CallbackManager mCallbackManager;
+    private final EventDispatcher mEventDispatcher;
 
     public RCTLoginButton(ThemedReactContext context, CallbackManager callbackManager) {
         super(context);
         this.setToolTipMode(ToolTipMode.NEVER_DISPLAY);
         mCallbackManager = callbackManager;
+        mEventDispatcher = UIManagerHelper.getEventDispatcherForReactTag((ReactContext) getContext(), getId());
         init();
     }
 
@@ -60,10 +63,8 @@ public class RCTLoginButton extends LoginButton {
                     WritableMap event = Arguments.createMap();
                     event.putString("type", "logoutFinished");
                     ReactContext context = (ReactContext) getContext();
-                    context.getJSModule(RCTEventEmitter.class).receiveEvent(
-                            getId(),
-                            "topChange",
-                            event);
+                    mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
+
                 }
             }
         };
@@ -85,10 +86,7 @@ public class RCTLoginButton extends LoginButton {
                                 setToStringArray(loginResult.getRecentlyDeniedPermissions())));
                 event.putMap("result", result);
                 ReactContext context = (ReactContext) getContext();
-                context.getJSModule(RCTEventEmitter.class).receiveEvent(
-                        getId(),
-                        "topChange",
-                        event);
+                mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
             }
 
             @Override
@@ -100,10 +98,7 @@ public class RCTLoginButton extends LoginButton {
                 result.putBoolean("isCancelled", false);
                 event.putMap("result", result);
                 ReactContext context = (ReactContext) getContext();
-                context.getJSModule(RCTEventEmitter.class).receiveEvent(
-                        getId(),
-                        "topChange",
-                        event);
+                mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
             }
 
             @Override
@@ -115,10 +110,7 @@ public class RCTLoginButton extends LoginButton {
                 result.putBoolean("isCancelled", true);
                 event.putMap("result", result);
                 ReactContext context = (ReactContext) getContext();
-                context.getJSModule(RCTEventEmitter.class).receiveEvent(
-                        getId(),
-                        "topChange",
-                        event);
+                mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
             }
         });
     }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButtonEvent.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButtonEvent.java
@@ -1,0 +1,27 @@
+package com.facebook.reactnative.androidsdk;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+
+public class RCTLoginButtonEvent extends Event<RCTLoginButtonEvent> {
+    public static final String EVENT_NAME = "topChange";
+    private final WritableMap mEvent;
+
+    public RCTLoginButtonEvent(int surfaceId, int viewTag, WritableMap event) {
+        super(surfaceId,viewTag);
+        mEvent = event;
+    }
+
+    @NonNull
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    protected WritableMap getEventData() {
+        return mEvent;
+    }
+}

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.h
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.h
@@ -20,6 +20,6 @@
 
 #import <React/RCTViewManager.h>
 
-@interface RCTFBSDKLoginButtonManager : RCTViewManager <FBSDKLoginButtonDelegate>
+@interface RCTFBSDKLoginButtonManager : RCTViewManager
 
 @end

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
@@ -17,8 +17,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "RCTFBSDKLoginButtonManager.h"
+#import "RCTFBSDKLoginButtonView.h"
 
-#import <React/RCTBridge.h>
 #import <React/RCTComponentEvent.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
@@ -34,12 +34,12 @@ RCT_EXPORT_MODULE(RCTFBLoginButton)
 
 - (UIView *)view
 {
-  FBSDKLoginButton *loginButton = [[FBSDKLoginButton alloc] init];
-  loginButton.delegate = self;
-  return loginButton;
+  return [[RCTFBSDKLoginButtonView alloc] init];
 }
 
 #pragma mark - Properties
+
+RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(permissions, NSStringArray)
 
@@ -60,36 +60,5 @@ RCT_CUSTOM_VIEW_PROPERTY(tooltipBehaviorIOS, FBSDKLoginButtonTooltipBehavior, FB
   [view setTooltipBehavior:json ? [RCTConvert FBSDKLoginButtonTooltipBehavior:json] : FBSDKLoginButtonTooltipBehaviorAutomatic];
 }
 
-#pragma mark - FBSDKLoginButtonDelegate
-
-- (void)loginButton:(FBSDKLoginButton *)loginButton didCompleteWithResult:(FBSDKLoginManagerLoginResult *)result error:(NSError *)error
-{
-  NSDictionary *body = @{
-    @"type": @"loginFinished",
-    @"error": error ? RCTJSErrorFromNSError(error) : [NSNull null],
-    @"result": error ? [NSNull null] : @{
-      @"isCancelled": @(result.isCancelled),
-      @"grantedPermissions": result.isCancelled ? [NSNull null] : result.grantedPermissions.allObjects,
-      @"declinedPermissions": result.isCancelled ? [NSNull null] : result.declinedPermissions.allObjects,
-    },
-  };
-
-  RCTComponentEvent *event = [[RCTComponentEvent alloc] initWithName:@"topChange"
-                                                             viewTag:loginButton.reactTag
-                                                                body:body];
-  [self.bridge.eventDispatcher sendEvent:event];
-}
-
-- (void)loginButtonDidLogOut:(FBSDKLoginButton *)loginButton
-{
-  NSDictionary *body = @{
-    @"type": @"logoutFinished",
-  };
-
-  RCTComponentEvent *event = [[RCTComponentEvent alloc] initWithName:@"topChange"
-                                                             viewTag:loginButton.reactTag
-                                                                body:body];
-  [self.bridge.eventDispatcher sendEvent:event];
-}
 
 @end

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.h
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.h
@@ -1,0 +1,10 @@
+#import <FBSDKLoginKit/FBSDKLoginKit.h>
+
+#import <React/RCTComponent.h>
+#import <React/RCTEventDispatcher.h>
+
+@interface RCTFBSDKLoginButtonView: UIView<FBSDKLoginButtonDelegate>
+
+@property (nonatomic, copy) RCTBubblingEventBlock onChange;
+
+@end

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.m
@@ -1,0 +1,59 @@
+#import "RCTFBSDKLoginButtonView.h"
+
+#import <React/RCTComponentEvent.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTUtils.h>
+#import <React/UIView+React.h>
+
+
+@interface RCTFBSDKLoginButtonView ()
+
+@property (nonatomic, strong) FBSDKLoginButton *loginButton;
+
+@end
+
+@implementation RCTFBSDKLoginButtonView
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    self.loginButton = [[FBSDKLoginButton alloc] init];
+    self.loginButton.delegate = self;
+    self.loginButton.frame = self.bounds;
+    self.loginButton.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+
+    [self addSubview:_loginButton];
+
+    return self;
+  }
+  return self;
+}
+
+#pragma mark - FBSDKLoginButtonDelegate
+
+- (void)loginButton:(FBSDKLoginButton *)loginButton didCompleteWithResult:(FBSDKLoginManagerLoginResult *)result error:(NSError *)error
+{
+  NSDictionary *body = @{
+    @"type": @"loginFinished",
+    @"error": error ? RCTJSErrorFromNSError(error) : [NSNull null],
+    @"result": error ? [NSNull null] : @{
+      @"isCancelled": @(result.isCancelled),
+      @"grantedPermissions": result.isCancelled ? [NSNull null] : result.grantedPermissions.allObjects,
+      @"declinedPermissions": result.isCancelled ? [NSNull null] : result.declinedPermissions.allObjects,
+    },
+  };
+
+  self.onChange(body);
+}
+
+- (void)loginButtonDidLogOut:(FBSDKLoginButton *)loginButton
+{
+  NSDictionary *body = @{
+    @"type": @"logoutFinished",
+  };
+
+  self.onChange(body);
+}
+
+@end


### PR DESCRIPTION
### Summary 

This PR adds Android and iOS support for the new architecture relying on the compatibility layer. 

#### On Android 
two main changes were required for this to work:

1. Remove `static` from all functions annotated with `@ReactMethod` given that in bridgeless it would throw the following error 
<img src="https://github.com/thebergamo/react-native-fbsdk-next/assets/11707729/3c619e3b-461c-4de4-ae95-65d2c970c229" width="400" />

2. Use the event dispatcher to send events from the native side to JS and adding a RCTLoginButtonEvent class

#### On iOS 

Had to create a dedicated class for the RCTFBSDKLoginButton view in order to export the `onChange` view property of type  `RCTBubblingEventBlock` and declare this property on the UIView wrapping the button (`FBSDKLoginButton` is a final class and can't be extended)


### Test Plan:

Locally run `refresh-example` to update to the latest RC and tested Android and iOS on the old and new architectures

https://github.com/thebergamo/react-native-fbsdk-next/assets/11707729/891ab1aa-23c5-4ee0-a5e5-cb1ebee31700


https://github.com/thebergamo/react-native-fbsdk-next/assets/11707729/8fec570b-23b5-49f4-84bd-093ad2c60b57


