### PR TITLE
fix: loosen engine semver to be node 18+ not 20+

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,6 @@
   ],
   "packageManager": "yarn@3.6.4",
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION

- Fixes #561 

I believe v18+ will work for everyone as long as our CI is 20+ as required by our semantic release infrastructure

CI will be the test - if it passes, then the PR is good in general

*then* if a release works, it is 100% good, but no way to tell that until post-merge so I'll watch it as release happens