### PR TITLE
feat(ios): make all permitted user profile fields available when using limited login

### DIFF
--- a/ios/RCTFBSDK/core/RCTFBSDKProfile.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKProfile.m
@@ -35,6 +35,20 @@ static NSDictionary *RCTBuildProfileDict(void)
         @"linkURL": FBSDKProfile.currentProfile.linkURL ? FBSDKProfile.currentProfile.linkURL.relativeString : [NSNull null],
         @"userID": FBSDKProfile.currentProfile.userID ? FBSDKProfile.currentProfile.userID : [NSNull null],
         @"email": FBSDKProfile.currentProfile.email ? FBSDKProfile.currentProfile.email : [NSNull null],
+        @"refreshDate": FBSDKProfile.currentProfile.refreshDate ? @(FBSDKProfile.currentProfile.refreshDate.timeIntervalSince1970 * 1000) : [NSNull null],
+        @"friendIDs": FBSDKProfile.currentProfile.friendIDs ? FBSDKProfile.currentProfile.friendIDs : [NSNull null],
+        @"birthday": FBSDKProfile.currentProfile.birthday ? @(FBSDKProfile.currentProfile.birthday.timeIntervalSince1970 * 1000) : [NSNull null],
+        @"ageRange": FBSDKProfile.currentProfile.ageRange ? FBSDKProfile.currentProfile.ageRange : [NSNull null],
+        @"hometown": FBSDKProfile.currentProfile.hometown ? @{
+            @"id": FBSDKProfile.currentProfile.hometown.id,
+            @"name": FBSDKProfile.currentProfile.hometown.name
+        } : [NSNull null],
+        @"location": FBSDKProfile.currentProfile.location ? @{
+            @"id": FBSDKProfile.currentProfile.location.id,
+            @"name": FBSDKProfile.currentProfile.location.name
+        } : [NSNull null],
+        @"gender": FBSDKProfile.currentProfile.gender ? FBSDKProfile.currentProfile.gender : [NSNull null],
+        @"permissions": FBSDKProfile.currentProfile.permissions ? FBSDKProfile.currentProfile.permissions.allObjects : [NSNull null]
     };
 }
 

--- a/ios/RCTFBSDK/core/RCTFBSDKProfile.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKProfile.m
@@ -38,7 +38,10 @@ static NSDictionary *RCTBuildProfileDict(void)
         @"refreshDate": FBSDKProfile.currentProfile.refreshDate ? @(FBSDKProfile.currentProfile.refreshDate.timeIntervalSince1970 * 1000) : [NSNull null],
         @"friendIDs": FBSDKProfile.currentProfile.friendIDs ? FBSDKProfile.currentProfile.friendIDs : [NSNull null],
         @"birthday": FBSDKProfile.currentProfile.birthday ? @(FBSDKProfile.currentProfile.birthday.timeIntervalSince1970 * 1000) : [NSNull null],
-        @"ageRange": FBSDKProfile.currentProfile.ageRange ? FBSDKProfile.currentProfile.ageRange : [NSNull null],
+        @"ageRange": FBSDKProfile.currentProfile.ageRange ? @{
+            @"min": FBSDKProfile.currentProfile.ageRange.min,
+            @"max": FBSDKProfile.currentProfile.ageRange.max
+        } : [NSNull null],
         @"hometown": FBSDKProfile.currentProfile.hometown ? @{
             @"id": FBSDKProfile.currentProfile.hometown.id,
             @"name": FBSDKProfile.currentProfile.hometown.name

--- a/src/FBProfile.ts
+++ b/src/FBProfile.ts
@@ -1,7 +1,7 @@
 /**
  * @format
  */
-import { Platform, NativeModules } from 'react-native';
+import {Platform, NativeModules} from 'react-native';
 
 const Profile = NativeModules.FBProfile;
 
@@ -14,14 +14,14 @@ export type ProfileMap = {
   userID?: string | null;
   email?: string | null;
   name?: string | null;
-  refreshDate?: number | null,
-  friendIDs?: Array<string> | null,
-  birthday?: number | null,
-  ageRange?: { min: number, max: number } | null,
-  hometown?: { id: string, name: string } | null,
-  location?: { id: string, name: string } | null,
-  gender?: string | null,
-  permissions?: Array<string> | null
+  refreshDate?: number | null;
+  friendIDs?: Array<string> | null;
+  birthday?: number | null;
+  ageRange?: {min: number; max: number} | null;
+  hometown?: {id: string; name: string} | null;
+  location?: {id: string; name: string} | null;
+  gender?: string | null;
+  permissions?: Array<string> | null;
 };
 
 /**
@@ -95,21 +95,21 @@ class FBProfile {
    * IMPORTANT: This field will only be populated if your user has granted your application the 'user_age_range' permission and
    * limited login flow is used on iOS
    */
-  ageRange?: { min: number, max: number } | null;
+  ageRange?: {min: number; max: number} | null;
 
   /**
    * The user’s hometown.
    * IMPORTANT: This field will only be populated if your user has granted your application the 'user_hometown' permission and
    * limited login flow is used on iOS
    */
-  hometown?: { id: string, name: string } | null;
+  hometown?: {id: string; name: string} | null;
 
   /**
    * The user’s location.
    * IMPORTANT: This field will only be populated if your user has granted your application the 'user_location' permission and
    * limited login flow is used on iOS
    */
-  location?: { id: string, name: string } | null;
+  location?: {id: string; name: string} | null;
 
   /**
    * The user’s gender.
@@ -134,7 +134,9 @@ class FBProfile {
       this.email = profileMap.email;
     }
     this.name = profileMap.name;
-    this.refreshDate = profileMap.refreshDate ? new Date(profileMap.refreshDate) : null;
+    this.refreshDate = profileMap.refreshDate
+      ? new Date(profileMap.refreshDate)
+      : null;
     this.friendIDs = profileMap.friendIDs;
     this.birthday = profileMap.birthday ? new Date(profileMap.birthday) : null;
     this.ageRange = profileMap.ageRange;

--- a/src/FBProfile.ts
+++ b/src/FBProfile.ts
@@ -1,7 +1,7 @@
 /**
  * @format
  */
-import {Platform, NativeModules} from 'react-native';
+import { Platform, NativeModules } from 'react-native';
 
 const Profile = NativeModules.FBProfile;
 
@@ -14,6 +14,14 @@ export type ProfileMap = {
   userID?: string | null;
   email?: string | null;
   name?: string | null;
+  refreshDate?: number | null,
+  friendIDs?: Array<string> | null,
+  birthday?: number | null,
+  ageRange?: { min: number, max: number } | null,
+  hometown?: { id: string, name: string } | null,
+  location?: { id: string, name: string } | null,
+  gender?: string | null,
+  permissions?: Array<string> | null
 };
 
 /**
@@ -63,6 +71,58 @@ class FBProfile {
    */
   imageURL?: string | null;
 
+  /**
+   * The last time the profile data was fetched.
+   */
+  refreshDate?: Date | null;
+
+  /**
+   * A list of identifiers of the user’s friends.
+   * IMPORTANT: This field will only be populated if your user has granted your application the 'user_friends' permission and
+   * limited login flow is used on iOS
+   */
+  friendIDs?: Array<string> | null;
+
+  /**
+   * The user’s birthday.
+   * IMPORTANT: This field will only be populated if your user has granted your application the 'user_birthday' permission and
+   * limited login flow is used on iOS
+   */
+  birthday?: Date | null;
+
+  /**
+   * The user’s age range.
+   * IMPORTANT: This field will only be populated if your user has granted your application the 'user_age_range' permission and
+   * limited login flow is used on iOS
+   */
+  ageRange?: { min: number, max: number } | null;
+
+  /**
+   * The user’s hometown.
+   * IMPORTANT: This field will only be populated if your user has granted your application the 'user_hometown' permission and
+   * limited login flow is used on iOS
+   */
+  hometown?: { id: string, name: string } | null;
+
+  /**
+   * The user’s location.
+   * IMPORTANT: This field will only be populated if your user has granted your application the 'user_location' permission and
+   * limited login flow is used on iOS
+   */
+  location?: { id: string, name: string } | null;
+
+  /**
+   * The user’s gender.
+   * IMPORTANT: This field will only be populated if your user has granted your application the 'user_gender' permission and
+   * limited login flow is used on iOS
+   */
+  gender?: string | null;
+
+  /**
+   * The user’s granted permissions.
+   */
+  permissions?: Array<string> | null;
+
   constructor(profileMap: ProfileMap) {
     this.firstName = profileMap.firstName;
     this.lastName = profileMap.lastName;
@@ -74,6 +134,14 @@ class FBProfile {
       this.email = profileMap.email;
     }
     this.name = profileMap.name;
+    this.refreshDate = profileMap.refreshDate ? new Date(profileMap.refreshDate) : null;
+    this.friendIDs = profileMap.friendIDs;
+    this.birthday = profileMap.birthday ? new Date(profileMap.birthday) : null;
+    this.ageRange = profileMap.ageRange;
+    this.hometown = profileMap.hometown;
+    this.location = profileMap.location;
+    this.gender = profileMap.gender;
+    this.permissions = profileMap.permissions;
     Object.freeze(this);
   }
 


### PR DESCRIPTION
Since Graph API cannot be used, this seems to be the only way to access additional user profile fields such as user's birthday, as per [official documentation](https://developers.facebook.com/docs/facebook-login/limited-login/ios/).

Fixes #525

Test Plan:

I granted all personalisation permissions to my app via the developer portal and specified them during login.
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/e5b84195-690c-49c5-aa13-0cc0ceab26b1">

However, not all fields returned were populated even though the permission was granted.
<img width="380" alt="image" src="https://github.com/user-attachments/assets/425ea988-d106-41fc-a926-da14a9ec7a4f">

So I created a test profile for e2e testing to ensure all mappings are working.
<img width="479" alt="image" src="https://github.com/user-attachments/assets/32f7b0c4-bb76-4be5-bc46-5bf87b5b12d6">


