### PR TITLE
docs: Deeplink ordering note added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The `AppDelegate.m` file can only have one method for `openUrl`. If you're also 
   return NO;
 }
 ```
+**NOTE:** Always ensure that the `RCTLinkingManager` condition is added as the last condition in your deep linking logic. If placed before `FBSDKApplicationDelegate` condition, it will intercept the Facebook SSO link, treating it as a standard deep link. This misconfiguration will break the Facebook Single Sign-On (SSO) functionality, leading to unexpected behavior in your app. Proper ordering is critical for seamless SSO integration..
 
 ### Troubleshooting
 


### PR DESCRIPTION
**ISSUE**
My app has multiple SSO options set up. When I added Facebook SSO using this package, it worked fine for Android and some iOS devices as well. But for some iOS devices, the app navigates to the Facebook app to authenticate and switches back to my app with a deep link like `fbAppId://somePermissions%data%etc`.

After debugging for an entire day, I realized that I had put `RCTLinkinganager` condition before `FBSDKApplicationDelegate` and just changing the order fixed it.

I believe this short note would be helpful for anyone having multiple other SSOs while integrating this package