### PR TITLE
feat(android): adopt facebook-android-sdk v18.0.0

### DIFF
--- a/RNFBSDKExample/ios/Podfile.lock
+++ b/RNFBSDKExample/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - FBAEMKit (17.4.0):
-    - FBSDKCoreKit_Basics (= 17.4.0)
+  - FBAEMKit (18.0.0):
+    - FBSDKCoreKit_Basics (= 18.0.0)
   - FBLazyVector (0.76.5)
-  - FBSDKCoreKit (17.4.0):
-    - FBAEMKit (= 17.4.0)
-    - FBSDKCoreKit_Basics (= 17.4.0)
-  - FBSDKCoreKit_Basics (17.4.0)
-  - FBSDKGamingServicesKit (17.4.0):
-    - FBSDKCoreKit (= 17.4.0)
-    - FBSDKCoreKit_Basics (= 17.4.0)
-    - FBSDKShareKit (= 17.4.0)
-  - FBSDKLoginKit (17.4.0):
-    - FBSDKCoreKit (= 17.4.0)
-  - FBSDKShareKit (17.4.0):
-    - FBSDKCoreKit (= 17.4.0)
+  - FBSDKCoreKit (18.0.0):
+    - FBAEMKit (= 18.0.0)
+    - FBSDKCoreKit_Basics (= 18.0.0)
+  - FBSDKCoreKit_Basics (18.0.0)
+  - FBSDKGamingServicesKit (18.0.0):
+    - FBSDKCoreKit (= 18.0.0)
+    - FBSDKCoreKit_Basics (= 18.0.0)
+    - FBSDKShareKit (= 18.0.0)
+  - FBSDKLoginKit (18.0.0):
+    - FBSDKCoreKit (= 18.0.0)
+  - FBSDKShareKit (18.0.0):
+    - FBSDKCoreKit (= 18.0.0)
   - fmt (9.1.0)
   - glog (0.3.5)
   - hermes-engine (0.76.5):
@@ -1262,14 +1262,14 @@ PODS:
     - react-native-fbsdk-next/Login (= 13.3.0)
     - react-native-fbsdk-next/Share (= 13.3.0)
   - react-native-fbsdk-next/Core (13.3.0):
-    - FBSDKCoreKit (~> 17.4)
+    - FBSDKCoreKit (~> 18.0)
     - React-Core
   - react-native-fbsdk-next/Login (13.3.0):
-    - FBSDKLoginKit (~> 17.4)
+    - FBSDKLoginKit (~> 18.0)
     - React-Core
   - react-native-fbsdk-next/Share (13.3.0):
-    - FBSDKGamingServicesKit (~> 17.4)
-    - FBSDKShareKit (~> 17.4)
+    - FBSDKGamingServicesKit (~> 18.0)
+    - FBSDKShareKit (~> 18.0)
     - React-Core
   - React-nativeconfig (0.76.5)
   - React-NativeModulesApple (0.76.5):
@@ -1753,13 +1753,13 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
-  FBAEMKit: 58cb5f302cdd715a56d4c1d0dfdd2e423ac1421a
+  FBAEMKit: e34530df538b8eb8aeb53c35867715ba6c63ef0c
   FBLazyVector: 1bf99bb46c6af9a2712592e707347315f23947aa
-  FBSDKCoreKit: 94d7461d0cecf441b1ba7c41acfff41daa8ccd41
-  FBSDKCoreKit_Basics: 151b43db8b834d3f0e02f95d36a44ffd36265e45
-  FBSDKGamingServicesKit: 55a13febe0cd117bf5f8f61f315d75aab9b7876e
-  FBSDKLoginKit: 5c1cd53c91a2282b3a4fe6e6d3dcf2b8b0d33d55
-  FBSDKShareKit: 00546a02dce72f37a4209cd68aaf5fb749185c3b
+  FBSDKCoreKit: d3f479a69127acebb1c6aad91c1a33907bcf6c2f
+  FBSDKCoreKit_Basics: 017b6dc2a1862024815a8229e75661e627ac1e29
+  FBSDKGamingServicesKit: cdb625419879a651d07906d8f874fc76291be660
+  FBSDKLoginKit: 5875762d1fe09ddcb05d03365d4f5dc34413843d
+  FBSDKShareKit: 082d1b087d6481af36f8d8433542f25f2fc2c8dd
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 06a9c6900587420b90accc394199527c64259db4
@@ -1792,7 +1792,7 @@ SPEC CHECKSUMS:
   React-logger: 697873f06b8ba436e3cddf28018ab4741e8071b6
   React-Mapbuffer: c174e11bdea12dce07df8669d6c0dc97eb0c7706
   React-microtasksnativemodule: 8a80099ad7391f4e13a48b12796d96680f120dc6
-  react-native-fbsdk-next: b430fc002cf9b8675b8688d43fe6eddd5ff4e029
+  react-native-fbsdk-next: 725e15c6190868e909cdb8071cb27078c2200512
   React-nativeconfig: f7ab6c152e780b99a8c17448f2d99cf5f69a2311
   React-NativeModulesApple: 70600f7edfc2c2a01e39ab13a20fd59f4c60df0b
   React-perflogger: ceb97dd4e5ca6ff20eebb5a6f9e00312dcdea872
@@ -1821,7 +1821,7 @@ SPEC CHECKSUMS:
   ReactCodegen: daa13d9e48c9bdb1daac4bd694b9dd54e06681df
   ReactCommon: a6b87a7591591f7a52d9c0fec3aa05e0620d5dd3
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: fcc198acd4a55599b3468cfb6ebc526baff5f06e
+  Yoga: c7ea4c36c1d78ebbf45529b6e78283e4e0fe4956
 
 PODFILE CHECKSUM: 3b32e4fda303c82bf98f66487ee14801c2093086
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ repositories {
     google()
 }
 
-def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '17.+')
+def FACEBOOK_SDK_VERSION = safeExtGet('facebookSdkVersion', '18.+')
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/react-native-fbsdk-next.podspec
+++ b/react-native-fbsdk-next.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, './', 'package.json')))
 
-FBSDKVersion = "17.4"
+FBSDKVersion = "18.0"
 
 Pod::Spec.new do |s|
   s.name          = package['name']


### PR DESCRIPTION
This pull request updates the Android Facebook SDK to version 18. 
- Reason: SDK v18 introduces better support for Google Play Billing Library v5 - v7
- Tested: Verified on both Android and iOS using the example app.
- No breaking changes observed.