### PR TITLE
fix: add replace for the new AD_SERVICES_CONFIG introduced in V18

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
            
            https://github.com/thebergamo/react-native-fbsdk-next/issues/597
       -->
-      <manifest package="com.facebook.reactnative.androidsdk"
+<manifest package="com.facebook.reactnative.androidsdk"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <application>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,7 +18,23 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<manifest package="com.facebook.reactnative.androidsdk"
+      <!--
+          This may generate a warning during your build:
+          
+           > property#android.adservices.AD_SERVICES_CONFIG@android:resource
+           > was tagged at AndroidManifest.xml:23 to replace other declarations
+           > but no other declaration present
+           
+           You may safely ignore this warning.
+           
+           We must include this in case you also use something else
+           that may also include this file, because if two modules include it, they
+           will collide and cause a build error if we don't set this one to take
+           priority via replacement.
+           
+           https://github.com/thebergamo/react-native-fbsdk-next/issues/597
+      -->
+      <manifest package="com.facebook.reactnative.androidsdk"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <application>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,6 +18,13 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<manifest
-    package="com.facebook.reactnative.androidsdk">
+<manifest package="com.facebook.reactnative.androidsdk"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <property
+            android:name="android.adservices.AD_SERVICES_CONFIG"
+            android:resource="@xml/ad_services_config"
+            tools:replace="android:resource" />
+    </application>
 </manifest>


### PR DESCRIPTION
Facebook SDK 18 introduced [Google Privacy Sandbox adservices API](https://github.com/facebook/facebook-android-sdk/commit/142b47a8beaa2ca23ac049ac8b96e837399457c2), and when this SDK was updated to 18, that change was pulled in here in https://github.com/thebergamo/react-native-fbsdk-next/pull/595. This means that if a user has a package that tries to declare the same resource either A) The user has to do this override in their AndroidManifest or B) We do it here like how [react-native-google-mobile-ads](https://github.com/invertase/react-native-google-mobile-ads/pull/660) does it

- Fixes #596
- Fixes #597 

Test Plan:

1. I made the changes locally on my own project in Android Studio and made sure that it compiled successfully:
<img width="1611" alt="Screenshot 2025-01-26 at 09 01 40" src="https://github.com/user-attachments/assets/ec900116-7bee-441c-a3a3-8d0fbbab9b79" />

2. I made the change to the source code, changed the fork's example apps's npm package to github:TheRogue76/react-native-fbsdk-next and pulled my latest changes, made sure that it compiled successfully (Metro was giving warnings that the module doesn't exist in the simulator, but it did compile and i double checked that my manifest merger change in Android was present):
<img width="1512" alt="Screenshot 2025-01-26 at 09 03 49" src="https://github.com/user-attachments/assets/a0178f9a-bcee-4f1d-ac19-b9cdc405c230" />

Let me know if there is a better way of testing this locally. In Lottie, we link the package locally so changes could be pulled from the code right next to it so the example app can test what is already there