### PR TITLE
fix: remove redundant overriden method for setting data processing options

### DIFF
--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -33,11 +33,6 @@ RCT_EXPORT_METHOD(setAdvertiserTrackingEnabled:(BOOL)ATE resolver:(RCTPromiseRes
   resolve(@(true)); // true means successfully changed
 }
 
-RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options)
-{
-  [FBSDKSettings.sharedSettings setDataProcessingOptions:options];
-}
-
 RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options country:(int)country state:(int)state)
 {
   [FBSDKSettings.sharedSettings setDataProcessingOptions:options country:country state:state];


### PR DESCRIPTION
### Symptom

After we upgraded the react-native to the `v0.79.2` for our project, we caught many `Exception in HostFunction: <unknown>` errors on Sentry, the error origin is the `setDataProcessingOptions` method in the `RCTFBSDKSettings.m` module, after tracing the code flow, we found it's because of there is a function override of `setDataProcessingOptions:(nullable NSArray<NSString *> *)options`, seems that the `RCT_EXPORT_METHOD` macro in the new versions of RN already dropped the support for such kind of function override.

It should be safe to remove this function override mentioned above, because,
1. We already applied this change by package patch in our production app for several months, the error occurrence has stopped completely and there're no new issues introduced by this change.
2. Seems that this function override isn't used at all, in the corresponding JavaScript part, it only calls the function variant of `setDataProcessingOptions:(nullable NSArray<NSString *> *)options country:(int)country state:(int)state`
<img width="1592" height="1162" alt="image" src="https://github.com/user-attachments/assets/92d45e0c-eb8a-4e63-992b-38f3ff613070" />


Test Plan:

Test the `setDataProcessingOptions` API under the react-native 0.79.

