### PR TITLE
fix(ios): native crashes when using native props

### DIFF
--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
@@ -41,23 +41,32 @@ RCT_EXPORT_MODULE(RCTFBLoginButton)
 
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
-RCT_EXPORT_VIEW_PROPERTY(permissions, NSStringArray)
-
-RCT_EXPORT_VIEW_PROPERTY(defaultAudience, FBSDKDefaultAudience)
-
-RCT_CUSTOM_VIEW_PROPERTY(nonceIOS, NSString, FBSDKLoginButton)
+RCT_CUSTOM_VIEW_PROPERTY(permissions, NSStringArray, RCTFBSDKLoginButtonView)
 {
-    [view setNonce:json ? json : nil];
+    [view.loginButton setPermissions:json ? json : nil];
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(loginTrackingIOS, NSString, FBSDKLoginButton)
+RCT_CUSTOM_VIEW_PROPERTY(defaultAudience, FBSDKDefaultAudience, RCTFBSDKLoginButtonView)
 {
-    [view setLoginTracking:([json isEqualToString:@"limited"]) ? FBSDKLoginTrackingLimited : FBSDKLoginTrackingEnabled];
+    if (json)
+    {
+        [view.loginButton setDefaultAudience:[RCTConvert FBSDKDefaultAudience:json]];
+    }
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(tooltipBehaviorIOS, FBSDKLoginButtonTooltipBehavior, FBSDKLoginButton)
+RCT_CUSTOM_VIEW_PROPERTY(nonceIOS, NSString, RCTFBSDKLoginButtonView)
 {
-  [view setTooltipBehavior:json ? [RCTConvert FBSDKLoginButtonTooltipBehavior:json] : FBSDKLoginButtonTooltipBehaviorAutomatic];
+    [view.loginButton setNonce:json ? json : nil];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(loginTrackingIOS, NSString, RCTFBSDKLoginButtonView)
+{
+    [view.loginButton setLoginTracking:([json isEqualToString:@"limited"]) ? FBSDKLoginTrackingLimited : FBSDKLoginTrackingEnabled];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(tooltipBehaviorIOS, FBSDKLoginButtonTooltipBehavior, RCTFBSDKLoginButtonView)
+{
+  [view.loginButton setTooltipBehavior:json ? [RCTConvert FBSDKLoginButtonTooltipBehavior:json] : FBSDKLoginButtonTooltipBehaviorAutomatic];
 }
 
 

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.h
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.h
@@ -5,6 +5,8 @@
 
 @interface RCTFBSDKLoginButtonView: UIView<FBSDKLoginButtonDelegate>
 
+@property (nonatomic, strong) FBSDKLoginButton *loginButton;
+
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 
 @end

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.m
@@ -8,8 +8,6 @@
 
 @interface RCTFBSDKLoginButtonView ()
 
-@property (nonatomic, strong) FBSDKLoginButton *loginButton;
-
 @end
 
 @implementation RCTFBSDKLoginButtonView


### PR DESCRIPTION
A critical issue was introduced by #505 that breaks usage of any of the following props on iOS platform:
- `permissions`
- `defaultAudience`
- `nonceIOS`
- `loginTrackingIOS`
- `tooltipBehaviorIOS`

Attempting to use any of these props will trigger the following **runtime** native error on mount:
```log
Thread 1: "-[RCTFBSDKLoginButtonView setPermissions:]: unrecognized selector sent to instance 0x133e15610"
```

This happens because the view exposed by native is not an instance of `FBSDKLoginButton` anymore, but a new wrapper `RCTFBSDKLoginButtonView` introduced in #505. Therefore, in the various `RCT_EXPORT_VIEW_PROPERTY` and `RCT_CUSTOM_VIEW_PROPERTY` macros, the `view` references point to the wrapper `RCTFBSDKLoginButtonView` which does not implement the properties itself.

This commit exposes the underlying `FBSDKLoginButton` property on the custom `RCTFBSDKLoginButtonView` wrapper, and re-exports these props as custom properties with the correct viewClass for correct static type checking.

> [!WARNING]
> I am not proficient in Objective-C. This should be extensively tested and checked as I might have made mistakes. Do *not* assume every use case has been tested!