### PR TITLE
fix: add withFacebookAppDelegate to support Swift AppDelegate (RN 0.77+)

### DIFF
--- a/plugin/src/__tests__/withFacebookAndroid-test.js
+++ b/plugin/src/__tests__/withFacebookAndroid-test.js
@@ -1,0 +1,134 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_1 = require("../config");
+const withFacebookAndroid_1 = require("../withFacebookAndroid");
+const config_plugins_1 = require("@expo/config-plugins");
+const path_1 = require("path");
+const xml2js_1 = require("xml2js");
+const { getMainApplication, readAndroidManifestAsync } = config_plugins_1.AndroidConfig.Manifest;
+const fixturesPath = (0, path_1.resolve)(__dirname, 'fixtures');
+const sampleManifestPath = (0, path_1.resolve)(fixturesPath, 'react-native-AndroidManifest.xml');
+const filledManifest = `<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.expo.mycoolapp">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="true"
+      android:theme="@style/AppTheme">
+
+      <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
+      <meta-data android:name="com.facebook.sdk.ApplicationName" android:value="my-display-name"/>
+      <meta-data android:name="com.facebook.sdk.AutoInitEnabled" android:value="true"/>
+      <meta-data android:name="com.facebook.sdk.AutoLogAppEventsEnabled" android:value="false"/>
+      <meta-data android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled" android:value="false"/>
+
+      <activity
+        android:name=".MainActivity"
+        android:launchMode="singleTask"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+
+      <activity android:name="com.facebook.CustomTabActivity" android:exported="true">
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+          <category android:name="android.intent.category.BROWSABLE"/>
+          <data android:scheme="myscheme"/>
+        </intent-filter>
+      </activity>
+    </application>
+
+</manifest>
+`;
+describe('Android facebook config', () => {
+    it(`returns null from all getters if no value provided`, () => {
+        expect((0, config_1.getFacebookScheme)({})).toBe(null);
+        expect((0, config_1.getFacebookAppId)({})).toBe(null);
+        expect((0, config_1.getFacebookDisplayName)({})).toBe(null);
+        expect((0, config_1.getFacebookAutoLogAppEvents)({})).toBe(null);
+        expect((0, config_1.getFacebookAutoInitEnabled)({})).toBe(null);
+        expect((0, config_1.getFacebookAdvertiserIDCollection)({})).toBe(null);
+    });
+    it(`returns correct value from all getters if value provided`, () => {
+        expect((0, config_1.getFacebookScheme)({ scheme: 'fbmyscheme' })).toMatch('fbmyscheme');
+        expect((0, config_1.getFacebookAppId)({ appID: 'my-app-id' })).toMatch('my-app-id');
+        expect((0, config_1.getFacebookDisplayName)({ displayName: 'my-display-name' })).toMatch('my-display-name');
+        expect((0, config_1.getFacebookAutoLogAppEvents)({ autoLogAppEventsEnabled: false })).toBe(false);
+        expect((0, config_1.getFacebookAutoInitEnabled)({ isAutoInitEnabled: true })).toBe(true);
+        expect((0, config_1.getFacebookAdvertiserIDCollection)({
+            advertiserIDCollectionEnabled: false,
+        })).toBe(false);
+    });
+    it('adds scheme, appid, display name, autolog events, auto init, advertiser id collection to androidmanifest.xml', async () => {
+        let androidManifestJson = await readAndroidManifestAsync(sampleManifestPath);
+        const facebookConfig = {
+            appID: 'my-app-id',
+            scheme: 'fbmyscheme',
+            displayName: 'my-display-name',
+            autoLogAppEventsEnabled: false,
+            isAutoInitEnabled: true,
+            advertiserIDCollectionEnabled: false,
+        };
+        androidManifestJson = (0, withFacebookAndroid_1.setFacebookConfig)(facebookConfig, androidManifestJson);
+        // Run this twice to ensure copies don't get added.
+        androidManifestJson = (0, withFacebookAndroid_1.setFacebookConfig)(facebookConfig, androidManifestJson);
+        const mainApplication = getMainApplication(androidManifestJson);
+        if (!mainApplication) {
+            throw new Error('Could not find main application');
+        }
+        const facebookActivity = mainApplication.activity?.filter((e) => e.$['android:name'] === 'com.facebook.FacebookActivity');
+        expect(facebookActivity).toHaveLength(1);
+        const customTabActivity = mainApplication.activity?.filter((e) => e.$['android:name'] === 'com.facebook.CustomTabActivity');
+        expect(customTabActivity).toHaveLength(1);
+        const applicationId = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationId');
+        expect(applicationId).toHaveLength(1);
+        expect(applicationId?.[0].$['android:value']).toMatch('@string/facebook_app_id');
+        const displayName = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationName');
+        expect(displayName).toHaveLength(1);
+        expect(displayName?.[0].$['android:value']).toMatch(facebookConfig.displayName);
+        const autoLogAppEventsEnabled = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.AutoLogAppEventsEnabled');
+        expect(autoLogAppEventsEnabled).toHaveLength(1);
+        expect(autoLogAppEventsEnabled?.[0].$['android:value']).toMatch(facebookConfig.autoLogAppEventsEnabled.toString());
+        const advertiserIDCollectionEnabled = mainApplication['meta-data']?.filter((e) => e.$['android:name'] ===
+            'com.facebook.sdk.AdvertiserIDCollectionEnabled');
+        expect(advertiserIDCollectionEnabled).toHaveLength(1);
+        expect(advertiserIDCollectionEnabled?.[0].$['android:value']).toMatch(facebookConfig.advertiserIDCollectionEnabled.toString());
+        const autoInitEnabled = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.AutoInitEnabled');
+        expect(autoInitEnabled).toHaveLength(1);
+        expect(autoInitEnabled?.[0].$['android:value']).toMatch(facebookConfig.isAutoInitEnabled.toString());
+    });
+    it('removes scheme, appid, display name, autolog events, auto init, advertiser id collection to androidmanifest.xml', async () => {
+        const parser = new xml2js_1.Parser();
+        let androidManifestJson = await parser.parseStringPromise(filledManifest);
+        const facebookConfig = {};
+        androidManifestJson = (0, withFacebookAndroid_1.setFacebookConfig)(facebookConfig, androidManifestJson);
+        const mainApplication = getMainApplication(androidManifestJson);
+        if (!mainApplication) {
+            throw new Error('Could not find main application');
+        }
+        const facebookActivity = mainApplication.activity?.filter((e) => e.$['android:name'] === 'com.facebook.CustomTabActivity');
+        expect(facebookActivity).toHaveLength(0);
+        const applicationId = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationId');
+        expect(applicationId).toHaveLength(0);
+        const displayName = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.ApplicationName');
+        expect(displayName).toHaveLength(0);
+        const autoLogAppEventsEnabled = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.AutoLogAppEventsEnabled');
+        expect(autoLogAppEventsEnabled).toHaveLength(0);
+        const advertiserIDCollectionEnabled = mainApplication['meta-data']?.filter((e) => e.$['android:name'] ===
+            'com.facebook.sdk.AdvertiserIDCollectionEnabled');
+        expect(advertiserIDCollectionEnabled).toHaveLength(0);
+        const autoInitEnabled = mainApplication['meta-data']?.filter((e) => e.$['android:name'] === 'com.facebook.sdk.AutoInitEnabled');
+        expect(autoInitEnabled).toHaveLength(0);
+    });
+});

--- a/plugin/src/__tests__/withFacebookIOS-test.js
+++ b/plugin/src/__tests__/withFacebookIOS-test.js
@@ -1,0 +1,75 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_1 = require("../config");
+const withFacebookIOS_1 = require("../withFacebookIOS");
+describe('ios facebook config', () => {
+    it(`returns null from all getters if no value provided`, () => {
+        expect((0, config_1.getFacebookScheme)({})).toBe(null);
+        expect((0, config_1.getFacebookAppId)({})).toBe(null);
+        expect((0, config_1.getFacebookDisplayName)({})).toBe(null);
+        expect((0, config_1.getFacebookAutoLogAppEvents)({})).toBe(null);
+        expect((0, config_1.getFacebookAutoInitEnabled)({})).toBe(null);
+        expect((0, config_1.getFacebookAdvertiserIDCollection)({})).toBe(null);
+    });
+    it(`returns correct value from all getters if value provided`, () => {
+        expect((0, config_1.getFacebookScheme)({ scheme: 'fbscheme' })).toMatch('fbscheme');
+        expect((0, config_1.getFacebookAppId)({ appID: 'my-app-id' })).toMatch('my-app-id');
+        expect((0, config_1.getFacebookDisplayName)({ displayName: 'my-display-name' })).toMatch('my-display-name');
+        expect((0, config_1.getFacebookAutoLogAppEvents)({ autoLogAppEventsEnabled: false })).toBe(false);
+        expect((0, config_1.getFacebookAutoInitEnabled)({ isAutoInitEnabled: true })).toBe(true);
+        expect((0, config_1.getFacebookAdvertiserIDCollection)({
+            advertiserIDCollectionEnabled: false,
+        })).toBe(false);
+    });
+    it('sets the facebook app id config', () => {
+        expect((0, withFacebookIOS_1.setFacebookAppId)({ appID: 'abc' }, {})).toStrictEqual({
+            FacebookAppID: 'abc',
+        });
+    });
+    it('sets the facebook client token config', () => {
+        expect((0, withFacebookIOS_1.setFacebookClientToken)({ clientToken: 'abc' }, {})).toStrictEqual({
+            FacebookClientToken: 'abc',
+        });
+    });
+    it('sets the facebook auto init config', () => {
+        expect((0, withFacebookIOS_1.setFacebookAutoInitEnabled)({ isAutoInitEnabled: true }, {})).toStrictEqual({
+            FacebookAutoInitEnabled: true,
+        });
+    });
+    it('sets the facebook advertising id enabled config', () => {
+        expect((0, withFacebookIOS_1.setFacebookAdvertiserIDCollectionEnabled)({ advertiserIDCollectionEnabled: true }, {})).toStrictEqual({
+            FacebookAdvertiserIDCollectionEnabled: true,
+        });
+    });
+    it('removes the facebook config', () => {
+        expect((0, withFacebookIOS_1.setFacebookConfig)({}, {
+            FacebookAdvertiserIDCollectionEnabled: true,
+            FacebookAppID: 'my-app-id',
+            FacebookClientToken: 'my-client-token',
+            FacebookAutoInitEnabled: true,
+            FacebookAutoLogAppEventsEnabled: true,
+            FacebookDisplayName: 'my-display-name',
+            LSApplicationQueriesSchemes: [
+                'fbapi',
+                'fb-messenger-api',
+                'fbauth2',
+                'fbshareextension',
+            ],
+        })).toStrictEqual({});
+    });
+    it('preserves the existing LSApplicationQueriesSchemes after removing the facebook schemes', () => {
+        const plist = (0, withFacebookIOS_1.setFacebookConfig)({}, {
+            LSApplicationQueriesSchemes: [
+                'expo',
+                'fbapi',
+                'fb-messenger-api',
+                'fbauth2',
+                'fbshareextension',
+            ],
+        });
+        // Test that running the command twice doesn't cause duplicates
+        expect((0, withFacebookIOS_1.setFacebookConfig)({}, plist)).toStrictEqual({
+            LSApplicationQueriesSchemes: ['expo'],
+        });
+    });
+});

--- a/plugin/src/__tests__/withSKAdNetworkIdentifiers-test.js
+++ b/plugin/src/__tests__/withSKAdNetworkIdentifiers-test.js
@@ -1,0 +1,56 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const withSKAdNetworkIdentifiers_1 = require("../withSKAdNetworkIdentifiers");
+describe(withSKAdNetworkIdentifiers_1.withSKAdNetworkIdentifiers, () => {
+    it(`adds ids to the Info.plist`, () => {
+        expect((0, withSKAdNetworkIdentifiers_1.withSKAdNetworkIdentifiers)({
+            name: 'foo',
+            slug: 'bar',
+        }, ['FOOBAR', 'other'])).toStrictEqual({
+            name: 'foo',
+            slug: 'bar',
+            ios: {
+                infoPlist: {
+                    SKAdNetworkItems: [
+                        {
+                            SKAdNetworkIdentifier: 'foobar',
+                        },
+                        {
+                            SKAdNetworkIdentifier: 'other',
+                        },
+                    ],
+                },
+            },
+        });
+    });
+    it(`prevents adding duplicate ids to the Info.plist`, () => {
+        expect((0, withSKAdNetworkIdentifiers_1.withSKAdNetworkIdentifiers)({
+            name: 'foo',
+            slug: 'bar',
+            ios: {
+                infoPlist: {
+                    SKAdNetworkItems: [
+                        {
+                            SKAdNetworkIdentifier: 'foobar',
+                        },
+                    ],
+                },
+            },
+        }, ['foobar', 'other'])).toStrictEqual({
+            name: 'foo',
+            slug: 'bar',
+            ios: {
+                infoPlist: {
+                    SKAdNetworkItems: [
+                        {
+                            SKAdNetworkIdentifier: 'foobar',
+                        },
+                        {
+                            SKAdNetworkIdentifier: 'other',
+                        },
+                    ],
+                },
+            },
+        });
+    });
+});

--- a/plugin/src/__tests__/withUserTrackingPermission-test.js
+++ b/plugin/src/__tests__/withUserTrackingPermission-test.js
@@ -1,0 +1,47 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const withFacebookIOS_1 = require("../withFacebookIOS");
+describe(withFacebookIOS_1.withUserTrackingPermission, () => {
+    it(`skips adding the permission when false`, () => {
+        expect((0, withFacebookIOS_1.withUserTrackingPermission)({ name: 'foo', slug: 'bar' }, { iosUserTrackingPermission: false })).toEqual({
+            name: 'foo',
+            slug: 'bar',
+        });
+    });
+    it(`sets custom user tracking description`, () => {
+        expect((0, withFacebookIOS_1.withUserTrackingPermission)({ name: 'foo', slug: 'bar' }, { iosUserTrackingPermission: 'custom tracking description' })).toEqual({
+            name: 'foo',
+            slug: 'bar',
+            ios: {
+                infoPlist: {
+                    NSUserTrackingUsageDescription: 'custom tracking description',
+                },
+            },
+        });
+    });
+    it(`does not add user tracking description by default`, () => {
+        expect((0, withFacebookIOS_1.withUserTrackingPermission)({ name: 'foo', slug: 'bar' }, {})).toStrictEqual({
+            name: 'foo',
+            slug: 'bar',
+        });
+    });
+    it(`does not overwrite existing user tracking description`, () => {
+        expect((0, withFacebookIOS_1.withUserTrackingPermission)({
+            name: 'foo',
+            slug: 'bar',
+            ios: {
+                infoPlist: {
+                    NSUserTrackingUsageDescription: 'existing user tracking description',
+                },
+            },
+        }, {})).toStrictEqual({
+            name: 'foo',
+            slug: 'bar',
+            ios: {
+                infoPlist: {
+                    NSUserTrackingUsageDescription: 'existing user tracking description',
+                },
+            },
+        });
+    });
+});

--- a/plugin/src/config.js
+++ b/plugin/src/config.js
@@ -1,0 +1,46 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getMergePropsWithConfig = getMergePropsWithConfig;
+exports.getFacebookAppId = getFacebookAppId;
+exports.getFacebookClientToken = getFacebookClientToken;
+exports.getFacebookScheme = getFacebookScheme;
+exports.getFacebookDisplayName = getFacebookDisplayName;
+exports.getFacebookAutoInitEnabled = getFacebookAutoInitEnabled;
+exports.getFacebookAutoLogAppEvents = getFacebookAutoLogAppEvents;
+exports.getFacebookAdvertiserIDCollection = getFacebookAdvertiserIDCollection;
+function getMergePropsWithConfig(config, props) {
+    const { appId: facebookAppId, displayName: facebookDisplayName, scheme: facebookScheme, autoInitEnabled: facebookAutoInitEnabled, autoLogAppEventsEnabled: facebookAutoLogAppEventsEnabled, advertiserIDCollectionEnabled: facebookAdvertiserIDCollectionEnabled, } = config.plugins.facebook;
+    const { appID = facebookAppId, clientToken, displayName = facebookDisplayName, scheme = facebookScheme ?? (appID ? `fb${appID}` : undefined), isAutoInitEnabled = facebookAutoInitEnabled ?? false, autoLogAppEventsEnabled = facebookAutoLogAppEventsEnabled ?? false, advertiserIDCollectionEnabled = facebookAdvertiserIDCollectionEnabled ??
+        false, iosUserTrackingPermission, } = (props ?? {});
+    return {
+        appID,
+        clientToken,
+        displayName,
+        scheme,
+        isAutoInitEnabled,
+        autoLogAppEventsEnabled,
+        advertiserIDCollectionEnabled,
+        iosUserTrackingPermission,
+    };
+}
+function getFacebookAppId(config) {
+    return config.appID ?? null;
+}
+function getFacebookClientToken(config) {
+    return config.clientToken ?? null;
+}
+function getFacebookScheme(config) {
+    return config.scheme ?? null;
+}
+function getFacebookDisplayName(config) {
+    return config.displayName ?? null;
+}
+function getFacebookAutoInitEnabled(config) {
+    return config.isAutoInitEnabled ?? null;
+}
+function getFacebookAutoLogAppEvents(config) {
+    return config.autoLogAppEventsEnabled ?? null;
+}
+function getFacebookAdvertiserIDCollection(config) {
+    return config.advertiserIDCollectionEnabled ?? null;
+}

--- a/plugin/src/withFacebook.js
+++ b/plugin/src/withFacebook.js
@@ -1,0 +1,61 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_1 = require("./config");
+const withFacebookAppDelegate_1 = require("./withFacebookAppDelegate");
+const withFacebookAndroid_1 = require("./withFacebookAndroid");
+const withFacebookIOS_1 = require("./withFacebookIOS");
+const withSKAdNetworkIdentifiers_1 = require("./withSKAdNetworkIdentifiers");
+const config_plugins_1 = require("@expo/config-plugins");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkg = require('react-native-fbsdk-next/package.json');
+function getExpoFacebookConfig(config) {
+    const facebookPlugin = config.plugins?.find((plugin) => {
+        if (Array.isArray(plugin) && plugin[0] === 'facebook') {
+            return true;
+        }
+        return false;
+    });
+    if (Array.isArray(facebookPlugin) && facebookPlugin.length > 1) {
+        return {
+            plugins: {
+                facebook: facebookPlugin[1],
+            },
+        };
+    }
+    return {
+        plugins: {
+            facebook: {},
+        },
+    };
+}
+const withFacebook = (config, props) => {
+    // Convert ExpoConfig to ExpoConfigFacebook format
+    const facebookConfig = getExpoFacebookConfig(config);
+    // Merge the configs
+    const newProps = (0, config_1.getMergePropsWithConfig)(facebookConfig, props);
+    // Validation
+    if (!newProps.appID) {
+        throw new Error('missing appID in the plugin properties');
+    }
+    if (!newProps.displayName) {
+        throw new Error('missing displayName in the plugin properties');
+    }
+    if (!newProps.scheme) {
+        throw new Error('missing scheme in the plugin properties');
+    }
+    // Android
+    config = (0, withFacebookAndroid_1.withFacebookAppIdString)(config, newProps);
+    config = (0, withFacebookAndroid_1.withFacebookManifest)(config, newProps);
+    config = (0, withFacebookAndroid_1.withAndroidPermissions)(config, newProps);
+    // iOS
+    config = (0, withFacebookIOS_1.withFacebookIOS)(config, newProps);
+    config = (0, withFacebookIOS_1.withUserTrackingPermission)(config, newProps);
+    config = (0, withFacebookAppDelegate_1.withFacebookAppDelegate)(config);
+    // https://developers.facebook.com/docs/SKAdNetwork
+    config = (0, withSKAdNetworkIdentifiers_1.withSKAdNetworkIdentifiers)(config, [
+        'v9wttpbfk9.skadnetwork',
+        'n38lu8286q.skadnetwork',
+    ]);
+    return config;
+};
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withFacebook, pkg.name, pkg.version);

--- a/plugin/src/withFacebook.ts
+++ b/plugin/src/withFacebook.ts
@@ -1,73 +1,75 @@
-import {ConfigProps, getMergePropsWithConfig} from './config';
+import { ConfigProps, getMergePropsWithConfig } from './config';
+import { withFacebookAppDelegate } from './withFacebookAppDelegate';
 import {
-  withAndroidPermissions,
-  withFacebookAppIdString,
-  withFacebookManifest,
+    withAndroidPermissions,
+    withFacebookAppIdString,
+    withFacebookManifest,
 } from './withFacebookAndroid';
-import {withFacebookIOS, withUserTrackingPermission} from './withFacebookIOS';
-import {withSKAdNetworkIdentifiers} from './withSKAdNetworkIdentifiers';
-import {ExpoConfig} from '@expo/config-types';
-import {ConfigPlugin, createRunOncePlugin} from '@expo/config-plugins';
+import { withFacebookIOS, withUserTrackingPermission } from './withFacebookIOS';
+import { withSKAdNetworkIdentifiers } from './withSKAdNetworkIdentifiers';
+import { ExpoConfig } from '@expo/config-types';
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('react-native-fbsdk-next/package.json');
 
 function getExpoFacebookConfig(config: ExpoConfig) {
-  const facebookPlugin = config.plugins?.find((plugin) => {
-    if (Array.isArray(plugin) && plugin[0] === 'facebook') {
-      return true;
+    const facebookPlugin = config.plugins?.find((plugin) => {
+        if (Array.isArray(plugin) && plugin[0] === 'facebook') {
+            return true;
+        }
+        return false;
+    });
+
+    if (Array.isArray(facebookPlugin) && facebookPlugin.length > 1) {
+        return {
+            plugins: {
+                facebook: facebookPlugin[1],
+            },
+        };
     }
-    return false;
-  });
 
-  if (Array.isArray(facebookPlugin) && facebookPlugin.length > 1) {
     return {
-      plugins: {
-        facebook: facebookPlugin[1],
-      },
+        plugins: {
+            facebook: {},
+        },
     };
-  }
-
-  return {
-    plugins: {
-      facebook: {},
-    },
-  };
 }
 
 const withFacebook: ConfigPlugin<ConfigProps | void> = (config, props) => {
-  // Convert ExpoConfig to ExpoConfigFacebook format
-  const facebookConfig = getExpoFacebookConfig(config);
+    // Convert ExpoConfig to ExpoConfigFacebook format
+    const facebookConfig = getExpoFacebookConfig(config);
 
-  // Merge the configs
-  const newProps = getMergePropsWithConfig(facebookConfig, props);
+    // Merge the configs
+    const newProps = getMergePropsWithConfig(facebookConfig, props);
 
-  // Validation
-  if (!newProps.appID) {
-    throw new Error('missing appID in the plugin properties');
-  }
-  if (!newProps.displayName) {
-    throw new Error('missing displayName in the plugin properties');
-  }
-  if (!newProps.scheme) {
-    throw new Error('missing scheme in the plugin properties');
-  }
+    // Validation
+    if (!newProps.appID) {
+        throw new Error('missing appID in the plugin properties');
+    }
+    if (!newProps.displayName) {
+        throw new Error('missing displayName in the plugin properties');
+    }
+    if (!newProps.scheme) {
+        throw new Error('missing scheme in the plugin properties');
+    }
 
-  // Android
-  config = withFacebookAppIdString(config, newProps);
-  config = withFacebookManifest(config, newProps);
-  config = withAndroidPermissions(config, newProps);
+    // Android
+    config = withFacebookAppIdString(config, newProps);
+    config = withFacebookManifest(config, newProps);
+    config = withAndroidPermissions(config, newProps);
 
-  // iOS
-  config = withFacebookIOS(config, newProps);
-  config = withUserTrackingPermission(config, newProps);
-  // https://developers.facebook.com/docs/SKAdNetwork
-  config = withSKAdNetworkIdentifiers(config, [
-    'v9wttpbfk9.skadnetwork',
-    'n38lu8286q.skadnetwork',
-  ]);
+    // iOS
+    config = withFacebookIOS(config, newProps);
+    config = withUserTrackingPermission(config, newProps);
+    config = withFacebookAppDelegate(config);
+    // https://developers.facebook.com/docs/SKAdNetwork
+    config = withSKAdNetworkIdentifiers(config, [
+        'v9wttpbfk9.skadnetwork',
+        'n38lu8286q.skadnetwork',
+    ]);
 
-  return config;
+    return config;
 };
 
 export default createRunOncePlugin(withFacebook, pkg.name, pkg.version);

--- a/plugin/src/withFacebookAndroid.js
+++ b/plugin/src/withFacebookAndroid.js
@@ -1,0 +1,197 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAndroidPermissions = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
+exports.setFacebookConfig = setFacebookConfig;
+const config_1 = require("./config");
+const config_plugins_1 = require("@expo/config-plugins");
+const { buildResourceItem } = config_plugins_1.AndroidConfig.Resources;
+const { removeStringItem, setStringItem } = config_plugins_1.AndroidConfig.Strings;
+const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, prefixAndroidKeys, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
+const FACEBOOK_ACTIVITY = 'com.facebook.FacebookActivity';
+const CUSTOM_TAB_ACTIVITY = 'com.facebook.CustomTabActivity';
+const STRING_FACEBOOK_APP_ID = 'facebook_app_id';
+const STRING_FB_LOGIN_PROTOCOL_SCHEME = 'fb_login_protocol_scheme';
+const STRING_FACEBOOK_CLIENT_TOKEN = 'facebook_client_token';
+const META_APP_ID = 'com.facebook.sdk.ApplicationId';
+const META_CLIENT_TOKEN = 'com.facebook.sdk.ClientToken';
+const META_APP_NAME = 'com.facebook.sdk.ApplicationName';
+const META_AUTO_INIT = 'com.facebook.sdk.AutoInitEnabled';
+const META_AUTO_LOG_APP_EVENTS = 'com.facebook.sdk.AutoLogAppEventsEnabled';
+const META_AD_ID_COLLECTION = 'com.facebook.sdk.AdvertiserIDCollectionEnabled';
+const withFacebookAppIdString = (config, props) => {
+    return (0, config_plugins_1.withStringsXml)(config, (config) => {
+        config.modResults = applyFacebookAppIdString(props, config.modResults);
+        config.modResults = applyFacebookClientTokenString(props, config.modResults);
+        config.modResults = applyFacebookLoginProtocolSchemeString(props, config.modResults);
+        return config;
+    });
+};
+exports.withFacebookAppIdString = withFacebookAppIdString;
+const withFacebookManifest = (config, props) => {
+    return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+        config.modResults = setFacebookConfig(props, config.modResults);
+        return config;
+    });
+};
+exports.withFacebookManifest = withFacebookManifest;
+const withAndroidPermissions = (config) => {
+    config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+        'android.permission.INTERNET',
+    ]);
+    return config;
+};
+exports.withAndroidPermissions = withAndroidPermissions;
+function buildXMLItem({ head, children, }) {
+    return { ...(children ?? {}), $: head };
+}
+function buildAndroidItem(datum) {
+    const item = typeof datum === 'string' ? { name: datum } : datum;
+    const head = prefixAndroidKeys(item);
+    return buildXMLItem({ head });
+}
+function getFacebookActivity() {
+    /**
+  <activity android:name="com.facebook.FacebookActivity"
+      android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+      android:label="@string/app_name" />
+     */
+    return buildXMLItem({
+        head: prefixAndroidKeys({
+            name: FACEBOOK_ACTIVITY,
+            configChanges: 'keyboard|keyboardHidden|screenLayout|screenSize|orientation',
+            label: '@string/app_name',
+        }),
+    });
+}
+function getCustomTabActivity() {
+    /**
+  <activity
+      android:name="com.facebook.CustomTabActivity"
+      android:exported="true">
+      <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="@string/fb_login_protocol_scheme" />
+      </intent-filter>
+  </activity>
+     */
+    return buildXMLItem({
+        head: prefixAndroidKeys({
+            name: CUSTOM_TAB_ACTIVITY,
+            exported: 'true',
+        }),
+        children: {
+            'intent-filter': [
+                {
+                    action: [buildAndroidItem('android.intent.action.VIEW')],
+                    category: [
+                        buildAndroidItem('android.intent.category.DEFAULT'),
+                        buildAndroidItem('android.intent.category.BROWSABLE'),
+                    ],
+                    data: [
+                        buildAndroidItem({ scheme: '@string/fb_login_protocol_scheme' }),
+                    ],
+                },
+            ],
+        },
+    });
+}
+function ensureFacebookActivity({ mainApplication, scheme, }) {
+    if (Array.isArray(mainApplication.activity)) {
+        // Remove all Facebook CustomTabActivities first
+        mainApplication.activity = mainApplication.activity.filter((activity) => {
+            return ![FACEBOOK_ACTIVITY, CUSTOM_TAB_ACTIVITY].includes(activity.$?.['android:name']);
+        });
+    }
+    else {
+        mainApplication.activity = [];
+    }
+    // If a new scheme is defined, append it to the activity.
+    if (scheme) {
+        mainApplication.activity.push(getFacebookActivity());
+        mainApplication.activity.push(getCustomTabActivity());
+    }
+    return mainApplication;
+}
+function applyFacebookLoginProtocolSchemeString(props, stringsJSON) {
+    const scheme = (0, config_1.getFacebookScheme)(props);
+    if (scheme) {
+        return setStringItem([
+            buildResourceItem({
+                name: STRING_FB_LOGIN_PROTOCOL_SCHEME,
+                value: scheme,
+            }),
+        ], stringsJSON);
+    }
+    return removeStringItem(STRING_FB_LOGIN_PROTOCOL_SCHEME, stringsJSON);
+}
+function applyFacebookAppIdString(props, stringsJSON) {
+    const appID = (0, config_1.getFacebookAppId)(props);
+    if (appID) {
+        return setStringItem([buildResourceItem({ name: STRING_FACEBOOK_APP_ID, value: appID })], stringsJSON);
+    }
+    return removeStringItem(STRING_FACEBOOK_APP_ID, stringsJSON);
+}
+function applyFacebookClientTokenString(props, stringsJSON) {
+    const clientToken = (0, config_1.getFacebookClientToken)(props);
+    if (clientToken) {
+        return setStringItem([
+            buildResourceItem({
+                name: STRING_FACEBOOK_CLIENT_TOKEN,
+                value: clientToken,
+            }),
+        ], stringsJSON);
+    }
+    return removeStringItem(STRING_FACEBOOK_CLIENT_TOKEN, stringsJSON);
+}
+function setFacebookConfig(props, androidManifest) {
+    const scheme = (0, config_1.getFacebookScheme)(props);
+    const appID = (0, config_1.getFacebookAppId)(props);
+    const displayName = (0, config_1.getFacebookDisplayName)(props);
+    const clientToken = (0, config_1.getFacebookClientToken)(props);
+    const autoInitEnabled = (0, config_1.getFacebookAutoInitEnabled)(props);
+    const autoLogAppEvents = (0, config_1.getFacebookAutoLogAppEvents)(props);
+    const advertiserIdCollection = (0, config_1.getFacebookAdvertiserIDCollection)(props);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let mainApplication = getMainApplicationOrThrow(androidManifest);
+    mainApplication = ensureFacebookActivity({ scheme, mainApplication });
+    if (appID) {
+        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_APP_ID, `@string/${STRING_FACEBOOK_APP_ID}`);
+    }
+    else {
+        mainApplication = removeMetaDataItemFromMainApplication(mainApplication, META_APP_ID);
+    }
+    if (clientToken) {
+        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_CLIENT_TOKEN, `@string/${STRING_FACEBOOK_CLIENT_TOKEN}`);
+    }
+    else {
+        mainApplication = removeMetaDataItemFromMainApplication(mainApplication, META_CLIENT_TOKEN);
+    }
+    if (displayName) {
+        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_APP_NAME, displayName);
+    }
+    else {
+        mainApplication = removeMetaDataItemFromMainApplication(mainApplication, META_APP_NAME);
+    }
+    if (autoInitEnabled !== null) {
+        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_AUTO_INIT, autoInitEnabled ? 'true' : 'false');
+    }
+    else {
+        mainApplication = removeMetaDataItemFromMainApplication(mainApplication, META_AUTO_INIT);
+    }
+    if (autoLogAppEvents !== null) {
+        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_AUTO_LOG_APP_EVENTS, autoLogAppEvents ? 'true' : 'false');
+    }
+    else {
+        mainApplication = removeMetaDataItemFromMainApplication(mainApplication, META_AUTO_LOG_APP_EVENTS);
+    }
+    if (advertiserIdCollection !== null) {
+        mainApplication = addMetaDataItemToMainApplication(mainApplication, META_AD_ID_COLLECTION, advertiserIdCollection ? 'true' : 'false');
+    }
+    else {
+        // eslint-disable-next-line
+        mainApplication = removeMetaDataItemFromMainApplication(mainApplication, META_AD_ID_COLLECTION);
+    }
+    return androidManifest;
+}

--- a/plugin/src/withFacebookAppDelegate.js
+++ b/plugin/src/withFacebookAppDelegate.js
@@ -1,0 +1,62 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withFacebookAppDelegate = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const withFacebookAppDelegate = (config) => {
+    return (0, config_plugins_1.withAppDelegate)(config, (config) => {
+        const { contents, language } = config.modResults;
+        if (language === 'swift') {
+            config.modResults.contents = applySwiftAppDelegateChanges(contents);
+        }
+        else {
+            config.modResults.contents = applyObjcAppDelegateChanges(contents);
+        }
+        return config;
+    });
+};
+exports.withFacebookAppDelegate = withFacebookAppDelegate;
+// ─── Swift (React Native >= 0.77 / Expo SDK 53+) ───────────────────────────
+function applySwiftAppDelegateChanges(contents) {
+    // 1. Add import
+    if (!contents.includes('import FBSDKCoreKit')) {
+        contents = contents.replace(/^(import React.*)/m, `$1\nimport FBSDKCoreKit`);
+    }
+    // 2. Add SDK init inside didFinishLaunchingWithOptions
+    if (!contents.includes('ApplicationDelegate.shared.application(')) {
+        contents = contents.replace(/return super\.application\(application, didFinishLaunchingWithOptions:/, `ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)\n    return super.application(application, didFinishLaunchingWithOptions:`);
+    }
+    // 3. Add openURL override
+    if (!contents.includes('ApplicationDelegate.shared.application') ||
+        !contents.includes('open url: URL')) {
+        const openURLMethod = `
+  public override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    let handledByFB = ApplicationDelegate.shared.application(app, open: url, options: options)
+    let handledBySuper = super.application(app, open: url, options: options)
+    return handledByFB || handledBySuper
+  }
+`;
+        // Insert before the last closing brace of the class
+        contents = contents.replace(/^}$/m, `${openURLMethod}}`);
+    }
+    return contents;
+}
+// ─── Objective-C (React Native <= 0.76) ────────────────────────────────────
+function applyObjcAppDelegateChanges(contents) {
+    // 1. Add imports
+    if (!contents.includes('FBSDKCoreKit-Swift.h')) {
+        contents = contents.replace(/#import <React\/RCTBridge.h>/, `#import <React/RCTBridge.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+#import <SafariServices/SafariServices.h>
+#import <FBSDKCoreKit/FBSDKCoreKit-Swift.h>`);
+    }
+    // 2. Add SDK init inside didFinishLaunchingWithOptions
+    if (!contents.includes('FBSDKApplicationDelegate')) {
+        contents = contents.replace(/return \[super application:application didFinishLaunchingWithOptions:launchOptions\];/, `[[FBSDKApplicationDelegate sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+  return [super application:application didFinishLaunchingWithOptions:launchOptions];`);
+    }
+    return contents;
+}

--- a/plugin/src/withFacebookAppDelegate.ts
+++ b/plugin/src/withFacebookAppDelegate.ts
@@ -1,0 +1,81 @@
+import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins';
+
+export const withFacebookAppDelegate: ConfigPlugin = (config) => {
+    return withAppDelegate(config, (config) => {
+        const { contents, language } = config.modResults;
+
+        if (language === 'swift') {
+            config.modResults.contents = applySwiftAppDelegateChanges(contents);
+        } else {
+            config.modResults.contents = applyObjcAppDelegateChanges(contents);
+        }
+
+        return config;
+    });
+};
+
+// ─── Swift (React Native >= 0.77 / Expo SDK 53+) ───────────────────────────
+
+function applySwiftAppDelegateChanges(contents: string): string {
+    // 1. Add import
+    if (!contents.includes('import FBSDKCoreKit')) {
+        contents = contents.replace(
+            /^(import React.*)/m,
+            `$1\nimport FBSDKCoreKit`
+        );
+    }
+
+    // 2. Add SDK init inside didFinishLaunchingWithOptions
+    if (!contents.includes('ApplicationDelegate.shared.application(')) {
+        contents = contents.replace(
+            /return super\.application\(application, didFinishLaunchingWithOptions:/,
+            `ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)\n    return super.application(application, didFinishLaunchingWithOptions:`
+        );
+    }
+
+    // 3. Add openURL override
+    if (!contents.includes('ApplicationDelegate.shared.application') ||
+        !contents.includes('open url: URL')) {
+        const openURLMethod = `
+  public override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    let handledByFB = ApplicationDelegate.shared.application(app, open: url, options: options)
+    let handledBySuper = super.application(app, open: url, options: options)
+    return handledByFB || handledBySuper
+  }
+`;
+        // Insert before the last closing brace of the class
+        contents = contents.replace(/^}$/m, `${openURLMethod}}`);
+    }
+
+    return contents;
+}
+
+// ─── Objective-C (React Native <= 0.76) ────────────────────────────────────
+
+function applyObjcAppDelegateChanges(contents: string): string {
+    // 1. Add imports
+    if (!contents.includes('FBSDKCoreKit-Swift.h')) {
+        contents = contents.replace(
+            /#import <React\/RCTBridge.h>/,
+            `#import <React/RCTBridge.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+#import <SafariServices/SafariServices.h>
+#import <FBSDKCoreKit/FBSDKCoreKit-Swift.h>`
+        );
+    }
+
+    // 2. Add SDK init inside didFinishLaunchingWithOptions
+    if (!contents.includes('FBSDKApplicationDelegate')) {
+        contents = contents.replace(
+            /return \[super application:application didFinishLaunchingWithOptions:launchOptions\];/,
+            `[[FBSDKApplicationDelegate sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+  return [super application:application didFinishLaunchingWithOptions:launchOptions];`
+        );
+    }
+
+    return contents;
+}

--- a/plugin/src/withFacebookIOS.js
+++ b/plugin/src/withFacebookIOS.js
@@ -1,0 +1,163 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withUserTrackingPermission = exports.withFacebookIOS = void 0;
+exports.setFacebookConfig = setFacebookConfig;
+exports.setFacebookScheme = setFacebookScheme;
+exports.setFacebookAutoInitEnabled = setFacebookAutoInitEnabled;
+exports.setFacebookAutoLogAppEventsEnabled = setFacebookAutoLogAppEventsEnabled;
+exports.setFacebookAdvertiserIDCollectionEnabled = setFacebookAdvertiserIDCollectionEnabled;
+exports.setFacebookAppId = setFacebookAppId;
+exports.setFacebookClientToken = setFacebookClientToken;
+exports.setFacebookDisplayName = setFacebookDisplayName;
+exports.setFacebookApplicationQuerySchemes = setFacebookApplicationQuerySchemes;
+const config_1 = require("./config");
+const config_plugins_1 = require("@expo/config-plugins");
+const { Scheme } = config_plugins_1.IOSConfig;
+const { appendScheme } = Scheme;
+const fbSchemes = ['fbapi', 'fb-messenger-api', 'fbauth2', 'fbshareextension'];
+const withFacebookIOS = (config, props) => {
+    return (0, config_plugins_1.withInfoPlist)(config, (config) => {
+        config.modResults = setFacebookConfig(props, config.modResults);
+        return config;
+    });
+};
+exports.withFacebookIOS = withFacebookIOS;
+function setFacebookConfig(config, infoPlist) {
+    infoPlist = setFacebookAppId(config, infoPlist);
+    infoPlist = setFacebookClientToken(config, infoPlist);
+    infoPlist = setFacebookApplicationQuerySchemes(config, infoPlist);
+    infoPlist = setFacebookDisplayName(config, infoPlist);
+    infoPlist = setFacebookAutoInitEnabled(config, infoPlist);
+    infoPlist = setFacebookAutoLogAppEventsEnabled(config, infoPlist);
+    infoPlist = setFacebookAdvertiserIDCollectionEnabled(config, infoPlist);
+    infoPlist = setFacebookScheme(config, infoPlist);
+    return infoPlist;
+}
+function setFacebookScheme(config, infoPlist) {
+    const facebookScheme = (0, config_1.getFacebookScheme)(config);
+    if (!facebookScheme) {
+        return infoPlist;
+    }
+    if (infoPlist.CFBundleURLTypes?.some(({ CFBundleURLSchemes }) => CFBundleURLSchemes.includes(facebookScheme))) {
+        return infoPlist;
+    }
+    return appendScheme(facebookScheme, infoPlist);
+}
+function setFacebookAutoInitEnabled(config, { FacebookAutoInitEnabled: _, ...infoPlist }) {
+    const isAutoInitEnabled = (0, config_1.getFacebookAutoInitEnabled)(config);
+    if (isAutoInitEnabled === null) {
+        return infoPlist;
+    }
+    return {
+        ...infoPlist,
+        FacebookAutoInitEnabled: isAutoInitEnabled,
+    };
+}
+function setFacebookAutoLogAppEventsEnabled(config, { FacebookAutoLogAppEventsEnabled: _, ...infoPlist }) {
+    const autoLogAppEventsEnabled = (0, config_1.getFacebookAutoLogAppEvents)(config);
+    if (autoLogAppEventsEnabled === null) {
+        return infoPlist;
+    }
+    return {
+        ...infoPlist,
+        FacebookAutoLogAppEventsEnabled: autoLogAppEventsEnabled,
+    };
+}
+function setFacebookAdvertiserIDCollectionEnabled(config, { FacebookAdvertiserIDCollectionEnabled: _, ...infoPlist }) {
+    const advertiserIDCollectionEnabled = (0, config_1.getFacebookAdvertiserIDCollection)(config);
+    if (advertiserIDCollectionEnabled === null) {
+        return infoPlist;
+    }
+    return {
+        ...infoPlist,
+        FacebookAdvertiserIDCollectionEnabled: advertiserIDCollectionEnabled,
+    };
+}
+function setFacebookAppId(config, { FacebookAppID: _, ...infoPlist }) {
+    const appID = (0, config_1.getFacebookAppId)(config);
+    if (appID) {
+        return {
+            ...infoPlist,
+            FacebookAppID: appID,
+        };
+    }
+    return infoPlist;
+}
+function setFacebookClientToken(config, { FacebookClientToken: _, ...infoPlist }) {
+    const clientToken = (0, config_1.getFacebookClientToken)(config);
+    if (clientToken) {
+        return {
+            ...infoPlist,
+            FacebookClientToken: clientToken,
+        };
+    }
+    return infoPlist;
+}
+function setFacebookDisplayName(config, { FacebookDisplayName: _, ...infoPlist }) {
+    const facebookDisplayName = (0, config_1.getFacebookDisplayName)(config);
+    if (facebookDisplayName) {
+        return {
+            ...infoPlist,
+            FacebookDisplayName: facebookDisplayName,
+        };
+    }
+    return infoPlist;
+}
+function setFacebookApplicationQuerySchemes(config, infoPlist) {
+    const facebookAppId = (0, config_1.getFacebookAppId)(config);
+    const existingSchemes = infoPlist.LSApplicationQueriesSchemes || [];
+    if (facebookAppId && existingSchemes.includes('fbapi')) {
+        // already included, no need to add again
+        return infoPlist;
+    }
+    else if (!facebookAppId && !existingSchemes.length) {
+        // already removed, no need to strip again
+        const { LSApplicationQueriesSchemes, ...restInfoPlist } = infoPlist;
+        if (LSApplicationQueriesSchemes?.length) {
+            return infoPlist;
+        }
+        else {
+            // Return without the empty LSApplicationQueriesSchemes array.
+            return restInfoPlist;
+        }
+    }
+    // Remove all schemes
+    for (const scheme of fbSchemes) {
+        const index = existingSchemes.findIndex((s) => s === scheme);
+        if (index > -1) {
+            existingSchemes.splice(index, 1);
+        }
+    }
+    if (!facebookAppId) {
+        // Run again to ensure the LSApplicationQueriesSchemes array is stripped if needed.
+        infoPlist.LSApplicationQueriesSchemes = existingSchemes;
+        if (!infoPlist.LSApplicationQueriesSchemes.length) {
+            delete infoPlist.LSApplicationQueriesSchemes;
+        }
+        return infoPlist;
+    }
+    // TODO: it's actually necessary to add more query schemes (specific to the
+    // app) to support all of the features that the Facebook SDK provides, should
+    // we sync those here too?
+    const updatedSchemes = [...existingSchemes, ...fbSchemes];
+    return {
+        ...infoPlist,
+        LSApplicationQueriesSchemes: updatedSchemes,
+    };
+}
+const withUserTrackingPermission = (config, { iosUserTrackingPermission } = {}) => {
+    if (!iosUserTrackingPermission) {
+        return config;
+    }
+    if (!config.ios) {
+        config.ios = {};
+    }
+    if (!config.ios.infoPlist) {
+        config.ios.infoPlist = {};
+    }
+    config.ios.infoPlist.NSUserTrackingUsageDescription =
+        iosUserTrackingPermission ||
+            config.ios.infoPlist.NSUserTrackingUsageDescription;
+    return config;
+};
+exports.withUserTrackingPermission = withUserTrackingPermission;

--- a/plugin/src/withSKAdNetworkIdentifiers.js
+++ b/plugin/src/withSKAdNetworkIdentifiers.js
@@ -1,0 +1,36 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withSKAdNetworkIdentifiers = void 0;
+/**
+ * Plugin to add [`SKAdNetworkIdentifier`](https://developer.apple.com/documentation/storekit/skadnetwork/configuring_the_participating_apps)s to the Info.plist safely.
+ *
+ *
+ * @param config
+ * @param props.identifiers array of lowercase string ids to push to the `SKAdNetworkItems` array in the `Info.plist`.
+ */
+const withSKAdNetworkIdentifiers = (config, identifiers) => {
+    if (!config.ios) {
+        config.ios = {};
+    }
+    if (!config.ios.infoPlist) {
+        config.ios.infoPlist = {};
+    }
+    if (!Array.isArray(config.ios.infoPlist.SKAdNetworkItems)) {
+        config.ios.infoPlist.SKAdNetworkItems = [];
+    }
+    // Get ids
+    let existingIds = config.ios.infoPlist.SKAdNetworkItems.map((item) => item?.SKAdNetworkIdentifier ?? null).filter(Boolean);
+    // remove duplicates
+    existingIds = [...new Set(existingIds)];
+    for (const id of identifiers) {
+        // Must be lowercase
+        const lower = id.toLowerCase();
+        if (!existingIds.includes(lower)) {
+            config.ios.infoPlist.SKAdNetworkItems.push({
+                SKAdNetworkIdentifier: lower,
+            });
+        }
+    }
+    return config;
+};
+exports.withSKAdNetworkIdentifiers = withSKAdNetworkIdentifiers;

--- a/src/FBAEMReporter.js
+++ b/src/FBAEMReporter.js
@@ -1,0 +1,34 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+const react_native_1 = require("react-native");
+/**
+ * Aggregated Event Measurement (AEM) for iOS apps allows for the measurement of app events
+ * from iOS 14.5+ users who have opted out of app tracking.
+ *
+ * @ref https://developers.facebook.com/docs/app-events/guides/aggregated-event-measurement/
+ */
+exports.default = {
+    /**
+     * Log AEM event, event names for AEM must match event names you used in app event logging.
+     *
+     * *This method will bypass if platform isn't iOS*
+     *
+     * **Make sure you also handle the DeepLink URL with AEM**
+     *
+     * @ref https://developers.facebook.com/docs/app-events/guides/aggregated-event-measurement/
+     * @platform iOS
+     */
+    logAEMEvent: (eventName, value, currency, otherParameters) => {
+        // AEM is currently only for iOS
+        if (react_native_1.Platform.OS !== 'ios') {
+            return;
+        }
+        react_native_1.NativeModules.FBSDKAEMReporter.recordAndUpdateEvent(eventName, value, currency, otherParameters);
+    },
+};

--- a/src/FBAccessToken.js
+++ b/src/FBAccessToken.js
@@ -1,0 +1,184 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+const react_native_1 = require("react-native");
+const AccessToken = react_native_1.NativeModules.FBAccessToken;
+const eventEmitter = new react_native_1.NativeEventEmitter(AccessToken);
+/**
+ * Represents an immutable access token for using Facebook services.
+ */
+class FBAccessToken {
+    /**
+     * The access token string.
+     */
+    accessToken;
+    /**
+     * The known granted permissions.
+     */
+    permissions;
+    /**
+     * The known declined permissions.
+     */
+    declinedPermissions;
+    /**
+     * The known expired permissions.
+     */
+    expiredPermissions;
+    /**
+     * The app ID.
+     */
+    applicationID;
+    /**
+     * The user ID.
+     */
+    userID;
+    /**
+     * The expiration time of the access token.
+     * The value is the number of milliseconds since Jan. 1, 1970, midnight GMT.
+     */
+    expirationTime;
+    /**
+     * The last refresh time of the access token.
+     * The value is the number of milliseconds since Jan. 1, 1970, midnight GMT.
+     */
+    lastRefreshTime;
+    /**
+     * The data access expiration time of the access token.
+     * The value is the number of milliseconds since Jan. 1, 1970, midnight GMT.
+     */
+    dataAccessExpirationTime;
+    /**
+     * The source of access token.
+     * @platform android
+     */
+    accessTokenSource;
+    constructor(tokenMap) {
+        this.accessToken = tokenMap.accessToken;
+        this.permissions = tokenMap.permissions;
+        this.declinedPermissions = tokenMap.declinedPermissions;
+        this.expiredPermissions = tokenMap.expiredPermissions;
+        this.applicationID = tokenMap.applicationID;
+        this.userID = tokenMap.userID;
+        this.expirationTime = tokenMap.expirationTime;
+        this.lastRefreshTime = tokenMap.lastRefreshTime;
+        this.dataAccessExpirationTime = tokenMap.dataAccessExpirationTime;
+        this.accessTokenSource = tokenMap.accessTokenSource;
+        Object.freeze(this);
+    }
+    /**
+     * Getter for the access token that is current for the application.
+     */
+    static getCurrentAccessToken() {
+        return new Promise((resolve) => {
+            AccessToken.getCurrentAccessToken((tokenMap) => {
+                if (tokenMap) {
+                    resolve(new FBAccessToken(tokenMap));
+                }
+                else {
+                    resolve(null);
+                }
+            });
+        });
+    }
+    /**
+     * Setter for the access token that is current for the application.
+     */
+    static setCurrentAccessToken(accessToken) {
+        AccessToken.setCurrentAccessToken(accessToken);
+    }
+    /**
+     * Updates the current access token with up to date permissions,
+     * and extends the expiration date, if extension is possible.
+     */
+    static refreshCurrentAccessTokenAsync() {
+        return AccessToken.refreshCurrentAccessTokenAsync();
+    }
+    /**
+     * Adds a listener for when the access token changes. Returns a functions which removes the
+     * listener when called.
+     */
+    static addListener(listener) {
+        const subscription = eventEmitter.addListener('fbsdk.accessTokenDidChange', (tokenMap) => {
+            if (tokenMap) {
+                listener(new FBAccessToken(tokenMap));
+            }
+            else {
+                listener(null);
+            }
+        });
+        return () => subscription.remove();
+    }
+    /**
+     * Gets the date at which the access token expires. The value is the number of
+     * milliseconds since Jan. 1, 1970, midnight GMT.
+     */
+    getExpires() {
+        return this.expirationTime;
+    }
+    /**
+     * Get the list of permissions associated with this access token. Note that the most up-to-date
+     * list of permissions is maintained by Facebook, so this list may be outdated if permissions
+     * have been added or removed since the time the AccessToken object was created. See
+     * https://developers.facebook.com/docs/reference/login/#permissions for details.
+     */
+    getPermissions() {
+        return this.permissions;
+    }
+    /**
+     * Gets the list of permissions declined by the user with this access token. It represents the
+     * entire set of permissions that have been requested and declined. Note that the most
+     * up-to-date list of permissions is maintained by Facebook, so this list may be outdated if
+     * permissions have been granted or declined since the last time an AccessToken object was
+     * created. See https://developers.facebook.com/docs/reference/login/#permissions for details.
+     */
+    getDeclinedPermissions() {
+        return this.declinedPermissions;
+    }
+    getExpiredPermissions() {
+        return this.expiredPermissions;
+    }
+    /**
+     * Gets the date at which the token was last refreshed. Since tokens expire, the Facebook SDK
+     * will attempt to renew them periodically. The value is the number of milliseconds since
+     * Jan. 1, 1970, midnight GMT.
+     */
+    getLastRefresh() {
+        return this.lastRefreshTime;
+    }
+    getDataAccessExpiration() {
+        return this.dataAccessExpirationTime;
+    }
+    /**
+     * Gets the ID of the Facebook Application associated with this access token.
+     */
+    getApplicationId() {
+        return this.applicationID;
+    }
+    /**
+     * Gets user ID associated with this access token.
+     */
+    getUserId() {
+        return this.userID;
+    }
+}
+exports.default = FBAccessToken;

--- a/src/FBAppEventsLogger.js
+++ b/src/FBAppEventsLogger.js
@@ -1,0 +1,202 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+const validate_1 = require("./util/validate");
+const react_native_1 = require("react-native");
+const react_native_2 = require("react-native");
+const AppEventsLogger = react_native_1.NativeModules.FBAppEventsLogger;
+const { AppEvents, AppEventParams, } = AppEventsLogger?.getConstants() || {};
+exports.default = {
+    /**
+     * Sets the current event flushing behavior specifying when events
+     * are sent back to Facebook servers.
+     */
+    setFlushBehavior(flushBehavior) {
+        AppEventsLogger.setFlushBehavior(flushBehavior);
+    },
+    /**
+     * Logs an event with eventName and optional arguments.
+     * This function supports the following usage:
+     * logEvent(eventName: string);
+     * logEvent(eventName: string, valueToSum: number);
+     * logEvent(eventName: string, parameters: {[key:string]:string|number});
+     * logEvent(eventName: string, valueToSum: number, parameters: {[key:string]:string|number});
+     * See https://developers.facebook.com/docs/app-events/android for detail.
+     */
+    logEvent(eventName, ...args) {
+        let valueToSum = 0;
+        if (typeof args[0] === 'number') {
+            valueToSum = Number(args.shift());
+        }
+        let parameters = null;
+        if (typeof args[0] === 'object') {
+            parameters = args[0];
+        }
+        AppEventsLogger.logEvent(eventName, valueToSum, parameters);
+    },
+    /**
+     * Logs a purchase. See http://en.wikipedia.org/wiki/ISO_4217 for currencyCode.
+     */
+    logPurchase(purchaseAmount, currencyCode, parameters) {
+        AppEventsLogger.logPurchase(purchaseAmount, currencyCode, parameters);
+    },
+    /**
+     * Logs an app event that tracks that the application was open via Push Notification.
+     */
+    logPushNotificationOpen(payload) {
+        AppEventsLogger.logPushNotificationOpen(payload);
+    },
+    /**
+     * Uploads product catalog product item as an app event
+     * @param itemID – Unique ID for the item. Can be a variant for a product. Max size is 100.
+     * @param availability – If item is in stock. Accepted values are: in stock - Item ships immediately out of stock - No plan to restock preorder - Available in future available for order - Ships in 1-2 weeks discontinued - Discontinued
+     * @param condition – Product condition: new, refurbished or used.
+     * @param description – Short text describing product. Max size is 5000.
+     * @param imageLink – Link to item image used in ad.
+     * @param link – Link to merchant's site where someone can buy the item.
+     * @param title – Title of item.
+     * @param priceAmount – Amount of purchase, in the currency specified by the 'currency' parameter. This value will be rounded to the thousandths place (e.g., 12.34567 becomes 12.346).
+     * @param currency – Currency used to specify the amount.
+     * @param gtin – Global Trade Item Number including UPC, EAN, JAN and ISBN
+     * @param mpn – Unique manufacture ID for product
+     * @param brand – Name of the brand Note: Either gtin, mpn or brand is required.
+     * @param parameters – Optional fields for deep link specification.
+     */
+    logProductItem(itemID, availability, condition, description, imageLink, link, title, priceAmount, currency, gtin, mpn, brand, parameters) {
+        if (!(0, validate_1.isDefined)(itemID) || !(0, validate_1.isString)(itemID)) {
+            throw new Error("logProductItem expected 'itemID' to be a string");
+        }
+        if (!(0, validate_1.isDefined)(availability) ||
+            !(0, validate_1.isOneOf)(availability, [
+                'in_stock',
+                'out_of_stock',
+                'preorder',
+                'avaliable_for_order',
+                'discontinued',
+            ])) {
+            throw new Error("logProductItem expected 'availability' to be one of 'in_stock' | 'out_of_stock' | 'preorder' | 'avaliable_for_order' | 'discontinued'");
+        }
+        if (!(0, validate_1.isDefined)(condition) ||
+            !(0, validate_1.isOneOf)(condition, ['new', 'refurbished', 'used'])) {
+            throw new Error("logProductItem expected 'condition' to be one of 'new' | 'refurbished' | 'used'");
+        }
+        if (!(0, validate_1.isDefined)(description) || !(0, validate_1.isString)(description)) {
+            throw new Error("logProductItem expected 'description' to be a string");
+        }
+        if (!(0, validate_1.isDefined)(imageLink) || !(0, validate_1.isString)(imageLink)) {
+            throw new Error("logProductItem expected 'imageLink' to be a string");
+        }
+        if (!(0, validate_1.isDefined)(link) || !(0, validate_1.isString)(link)) {
+            throw new Error("logProductItem expected 'link' to be a string");
+        }
+        if (!(0, validate_1.isDefined)(title) || !(0, validate_1.isString)(title)) {
+            throw new Error("logProductItem expected 'title' to be a string");
+        }
+        if (!(0, validate_1.isDefined)(priceAmount) || !(0, validate_1.isNumber)(priceAmount)) {
+            throw new Error("logProductItem expected 'priceAmount' to be a number");
+        }
+        if (!(0, validate_1.isDefined)(currency) || !(0, validate_1.isString)(currency)) {
+            throw new Error("logProductItem expected 'currency' to be a string");
+        }
+        if (!(0, validate_1.isDefined)(gtin) && !(0, validate_1.isDefined)(mpn) && !(0, validate_1.isDefined)(brand)) {
+            throw new Error('logProductItem expected either gtin, mpn or brand to be defined');
+        }
+        AppEventsLogger.logProductItem(itemID, availability, condition, description, imageLink, link, title, priceAmount, currency, gtin, mpn, brand, parameters);
+    },
+    /**
+     * Explicitly kicks off flushing of events to Facebook.
+     */
+    flush() {
+        AppEventsLogger.flush();
+    },
+    /**
+     * Sets a custom user ID to associate with all app events.
+     * The userID is persisted until this method is called again with a null userId
+     */
+    setUserID(userID) {
+        AppEventsLogger.setUserID(userID);
+    },
+    /**
+     * Clears the currently set user id.
+     * @deprecated use setUserID(null) instead
+     */
+    clearUserID() {
+        AppEventsLogger.clearUserID();
+    },
+    /**
+     * Returns user id or null if not set
+     */
+    async getUserID() {
+        return await AppEventsLogger.getUserID();
+    },
+    /**
+     * Returns anonymous id or null if not set
+     */
+    async getAnonymousID() {
+        return await AppEventsLogger.getAnonymousID();
+    },
+    /**
+     * Returns advertiser id or null if not set
+     */
+    async getAdvertiserID() {
+        return await AppEventsLogger.getAdvertiserID();
+    },
+    /**
+     * Returns advertiser id or null if not set.
+     * @platform android
+     */
+    async getAttributionID() {
+        if (react_native_2.Platform.OS === 'ios') {
+            return null;
+        }
+        return await AppEventsLogger.getAttributionID();
+    },
+    /**
+     * Set additional data about the user to increase chances of matching a Facebook user.
+     */
+    setUserData(userData) {
+        AppEventsLogger.setUserData(userData);
+    },
+    /**
+     * For iOS only, sets and sends device token to register the current application for push notifications.
+     * @platform ios
+     */
+    setPushNotificationsDeviceToken(deviceToken) {
+        AppEventsLogger.setPushNotificationsDeviceToken(deviceToken);
+    },
+    /**
+     * For Android only, sets and sends registration id to register the current app for push notifications.
+     * @platform Android
+     */
+    setPushNotificationsRegistrationId(registrationId) {
+        AppEventsLogger.setPushNotificationsRegistrationId(registrationId);
+    },
+    /**
+     * Predefined event names for logging events common to many apps.
+     */
+    AppEvents,
+    /**
+     *  Predefined event name parameters for common additional information to accompany events logged through the `logEvent`.
+     */
+    AppEventParams,
+};

--- a/src/FBAppLink.js
+++ b/src/FBAppLink.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+const react_native_1 = require("react-native");
+const AppLink = react_native_1.NativeModules.FBAppLink;
+exports.default = {
+    fetchDeferredAppLink() {
+        return AppLink.fetchDeferredAppLink();
+    },
+};

--- a/src/FBAuthenticationToken.js
+++ b/src/FBAuthenticationToken.js
@@ -1,0 +1,49 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * @format
+ */
+const react_native_1 = require("react-native");
+const AuthenticationToken = react_native_1.NativeModules.FBAuthenticationToken;
+/**
+ * Represents an immutable access token for using Facebook services.
+ */
+class FBAuthenticationToken {
+    /**
+       The raw token string from the authentication response
+      */
+    authenticationToken;
+    /**
+       The nonce from the decoded authentication response
+      */
+    nonce;
+    /**
+      The graph domain where the user is authenticated.
+     */
+    graphDomain;
+    constructor(tokenMap) {
+        this.authenticationToken = tokenMap.authenticationToken;
+        this.nonce = tokenMap.nonce;
+        this.graphDomain = tokenMap.graphDomain;
+        Object.freeze(this);
+    }
+    /**
+     * Getter for the authentication token
+     */
+    static getAuthenticationTokenIOS() {
+        if (react_native_1.Platform.OS === 'android') {
+            return Promise.resolve(null);
+        }
+        return new Promise((resolve) => {
+            AuthenticationToken.getAuthenticationToken((tokenMap) => {
+                if (tokenMap) {
+                    resolve(new FBAuthenticationToken(tokenMap));
+                }
+                else {
+                    resolve(null);
+                }
+            });
+        });
+    }
+}
+exports.default = FBAuthenticationToken;

--- a/src/FBGameRequestDialog.js
+++ b/src/FBGameRequestDialog.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_native_1 = require("react-native");
+const GameRequestDialog = react_native_1.NativeModules.FBGameRequestDialog;
+exports.default = {
+    /**
+     * Check if the dialog can be shown.
+     */
+    canShow() {
+        return GameRequestDialog.canShow();
+    },
+    /**
+     * Shows the dialog using the specified content.
+     */
+    show(gameRequestContent) {
+        return GameRequestDialog.show(gameRequestContent);
+    },
+};

--- a/src/FBGraphRequest.js
+++ b/src/FBGraphRequest.js
@@ -1,0 +1,57 @@
+"use strict";
+/**
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Represents a Graph API request and provides batch request supports.
+ */
+class FBGraphRequest {
+    /**
+     * The Graph API endpoint to use for the request, for example "me".
+     */
+    graphPath;
+    /**
+     * The optional config for the request.
+     */
+    config;
+    /**
+     * Called upon completion or failure of the request.
+     */
+    callback;
+    /**
+     * Constructs a new Graph API request.
+     */
+    constructor(graphPath, config, callback) {
+        this.graphPath = graphPath;
+        this.config = config ? config : {};
+        this.callback = callback ? callback : () => null;
+    }
+    /**
+     * Adds a string parameter to the request.
+     */
+    addStringParameter(paramString, key) {
+        if (this.config != null && this.config.parameters != null) {
+            this.config.parameters[key] = { string: paramString };
+        }
+    }
+}
+exports.default = FBGraphRequest;

--- a/src/FBGraphRequestManager.js
+++ b/src/FBGraphRequestManager.js
@@ -1,0 +1,70 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_native_1 = require("react-native");
+const NativeGraphRequestManager = react_native_1.NativeModules.FBGraphRequest;
+function _verifyParameters(request) {
+    if (request.config?.parameters) {
+        for (const key in request.config.parameters) {
+            const param = request.config.parameters[key];
+            if (typeof param === 'object' &&
+                param?.string) {
+                continue;
+            }
+            throw new Error("Unexpected value for parameter '" +
+                key +
+                "'. Request parameters " +
+                "need to be objects with a 'string' field.");
+        }
+    }
+}
+class FBGraphRequestManager {
+    requestBatch = [];
+    requestCallbacks = [];
+    batchCallback = null;
+    /**
+     * Add a graph request.
+     */
+    addRequest(request) {
+        _verifyParameters(request);
+        this.requestBatch.push(request);
+        this.requestCallbacks.push(request.callback);
+        return this;
+    }
+    /**
+     * Add call back to the GraphRequestManager. Only one callback can be added.
+     * Note that invocation of the batch callback does not indicate success of every
+     * graph request made, only that the entire batch has finished executing.
+     */
+    addBatchCallback(callback) {
+        this.batchCallback = callback;
+        return this;
+    }
+    /**
+     * Executes requests in a batch.
+     * Note that when there's an issue with network connection the batch callback
+     * behavior differs in Android and iOS.
+     * On iOS, the batch callback returns an error if the batch fails with a network error.
+     * On Android, the batch callback always returns {"result": "batch finished executing"}
+     * after the batch time out. This is because detecting network status requires
+     * extra permission and it's unncessary for the sdk. Instead, you can use the NetInfo module
+     * in react-native to get the network status.
+     */
+    start(timeout) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const that = this;
+        const callback = (error, result, response) => {
+            if (response) {
+                that.requestCallbacks.forEach((innerCallback, index) => {
+                    if (innerCallback) {
+                        innerCallback(response[index][0], response[index][1]);
+                    }
+                });
+            }
+            if (that.batchCallback) {
+                that.batchCallback(error, result);
+            }
+        };
+        NativeGraphRequestManager.start(this.requestBatch, timeout || 0, callback);
+    }
+}
+exports.default = FBGraphRequestManager;

--- a/src/FBLoginButton.js
+++ b/src/FBLoginButton.js
@@ -1,0 +1,73 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const React = __importStar(require("react"));
+const react_native_1 = require("react-native");
+/**
+ * A button that initiates a log in or log out flow upon tapping.
+ */
+class LoginButton extends React.Component {
+    static defaultProps;
+    _eventHandler(event) {
+        if (typeof event !== 'object' || !event || !event.nativeEvent) {
+            return;
+        }
+        const eventDict = event.nativeEvent;
+        if (eventDict.type === 'loginFinished') {
+            if (this.props.onLoginFinished) {
+                this.props.onLoginFinished(eventDict.error, eventDict.result);
+            }
+        }
+        else if (eventDict.type === 'logoutFinished') {
+            if (this.props.onLogoutFinished) {
+                this.props.onLogoutFinished();
+            }
+        }
+    }
+    render() {
+        return (<RCTFBLoginButton {...this.props} onChange={this._eventHandler.bind(this)}/>);
+    }
+}
+const styles = react_native_1.StyleSheet.create({
+    defaultButtonStyle: {
+        height: 30,
+        width: 190,
+    },
+});
+LoginButton.defaultProps = {
+    style: styles.defaultButtonStyle,
+};
+const RCTFBLoginButton = (0, react_native_1.requireNativeComponent)('RCTFBLoginButton');
+exports.default = LoginButton;

--- a/src/FBLoginManager.js
+++ b/src/FBLoginManager.js
@@ -1,0 +1,61 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_native_1 = require("react-native");
+const LoginManager = react_native_1.NativeModules.FBLoginManager;
+exports.default = {
+    /**
+     * Log in with the requested permissions.
+     * @param loginTrackingIOS IOS only: loginTracking: 'enabled' | 'limited', default 'enabled'.
+     * @param nonceIOS IOS only: Nonce that the configuration was created with. A unique nonce will be used if none is provided to the factory method.
+     */
+    logInWithPermissions(permissions, loginTrackingIOS, nonceIOS) {
+        if (react_native_1.Platform.OS === 'ios') {
+            return LoginManager.logInWithPermissions(permissions, loginTrackingIOS, nonceIOS);
+        }
+        return LoginManager.logInWithPermissions(permissions);
+    },
+    /**
+     * Getter for the login behavior.
+     */
+    getLoginBehavior() {
+        if (react_native_1.Platform.OS === 'ios') {
+            return Promise.resolve('browser');
+        }
+        else {
+            return LoginManager.getLoginBehavior();
+        }
+    },
+    /**
+     * Setter for the login behavior.
+     */
+    setLoginBehavior(loginBehavior) {
+        if (react_native_1.Platform.OS === 'ios') {
+            return;
+        }
+        LoginManager.setLoginBehavior(loginBehavior);
+    },
+    /**
+     * Getter for the default audience.
+     */
+    getDefaultAudience() {
+        return LoginManager.getDefaultAudience();
+    },
+    /**
+     * Setter for the default audience.
+     */
+    setDefaultAudience(defaultAudience) {
+        LoginManager.setDefaultAudience(defaultAudience);
+    },
+    /**
+     * Re-authorizes the user to update data access permissions.
+     */
+    reauthorizeDataAccess() {
+        return LoginManager.reauthorizeDataAccess();
+    },
+    /**
+     * Logs out the user.
+     */
+    logOut() {
+        LoginManager.logOut();
+    },
+};

--- a/src/FBMessageDialog.js
+++ b/src/FBMessageDialog.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_native_1 = require("react-native");
+const MessageDialog = react_native_1.NativeModules.FBMessageDialog;
+exports.default = {
+    /**
+     * Check if the dialog can be shown.
+     */
+    canShow(shareContent) {
+        return MessageDialog.canShow(shareContent);
+    },
+    /**
+     * Shows the dialog using the specified content.
+     */
+    show(shareContent) {
+        return MessageDialog.show(shareContent);
+    },
+    /**
+     * Sets whether or not the native message dialog should fail when it encounters a data error.
+     */
+    setShouldFailOnDataError(shouldFailOnDataError) {
+        MessageDialog.setShouldFailOnDataError(shouldFailOnDataError);
+    },
+};

--- a/src/FBProfile.js
+++ b/src/FBProfile.js
@@ -1,0 +1,130 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * @format
+ */
+const react_native_1 = require("react-native");
+const Profile = react_native_1.NativeModules.FBProfile;
+/**
+ * Represents an immutable Facebook profile
+ * This class provides a global "currentProfile" instance to more easily add social context to your application.
+ */
+class FBProfile {
+    /**
+     * The user id
+     */
+    userID;
+    /**
+     * The user's email.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'email' permission.
+     */
+    email;
+    /**
+     * The user's complete name
+     */
+    name;
+    /**
+     * The user's first name
+     */
+    firstName;
+    /**
+     * The user's last name
+     */
+    lastName;
+    /**
+     * The user's middle name
+     */
+    middleName;
+    /**
+     * A URL to the user's profile.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'user_link' permission
+     */
+    linkURL;
+    /**
+     * A URL to use for fetching a user's profile image.
+     */
+    imageURL;
+    /**
+     * The last time the profile data was fetched.
+     */
+    refreshDate;
+    /**
+     * A list of identifiers of the user’s friends.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'user_friends' permission and
+     * limited login flow is used on iOS
+     */
+    friendIDs;
+    /**
+     * The user’s birthday.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'user_birthday' permission and
+     * limited login flow is used on iOS
+     */
+    birthday;
+    /**
+     * The user’s age range.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'user_age_range' permission and
+     * limited login flow is used on iOS
+     */
+    ageRange;
+    /**
+     * The user’s hometown.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'user_hometown' permission and
+     * limited login flow is used on iOS
+     */
+    hometown;
+    /**
+     * The user’s location.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'user_location' permission and
+     * limited login flow is used on iOS
+     */
+    location;
+    /**
+     * The user’s gender.
+     * IMPORTANT: This field will only be populated if your user has granted your application the 'user_gender' permission and
+     * limited login flow is used on iOS
+     */
+    gender;
+    /**
+     * The user’s granted permissions.
+     */
+    permissions;
+    constructor(profileMap) {
+        this.firstName = profileMap.firstName;
+        this.lastName = profileMap.lastName;
+        this.middleName = profileMap.middleName;
+        this.linkURL = profileMap.linkURL;
+        this.imageURL = profileMap.imageURL;
+        this.userID = profileMap.userID;
+        if (react_native_1.Platform.OS !== 'android') {
+            this.email = profileMap.email;
+        }
+        this.name = profileMap.name;
+        this.refreshDate = profileMap.refreshDate
+            ? new Date(profileMap.refreshDate)
+            : null;
+        this.friendIDs = profileMap.friendIDs;
+        this.birthday = profileMap.birthday ? new Date(profileMap.birthday) : null;
+        this.ageRange = profileMap.ageRange;
+        this.hometown = profileMap.hometown;
+        this.location = profileMap.location;
+        this.gender = profileMap.gender;
+        this.permissions = profileMap.permissions;
+        Object.freeze(this);
+    }
+    /**
+     * Getter the current logged profile
+     */
+    static getCurrentProfile() {
+        return new Promise((resolve) => {
+            Profile.getCurrentProfile((profileMap) => {
+                if (profileMap) {
+                    resolve(new FBProfile(profileMap));
+                }
+                else {
+                    resolve(null);
+                }
+            });
+        });
+    }
+}
+exports.default = FBProfile;

--- a/src/FBSendButton.js
+++ b/src/FBSendButton.js
@@ -1,0 +1,54 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const React = __importStar(require("react"));
+const react_native_1 = require("react-native");
+class SendButton extends React.Component {
+    static defaultProps;
+    render() {
+        return <RCTFBSendButton {...this.props}/>;
+    }
+}
+const styles = react_native_1.StyleSheet.create({
+    defaultButtonStyle: {
+        height: 30,
+        width: 80,
+    },
+});
+SendButton.defaultProps = {
+    style: styles.defaultButtonStyle,
+};
+const RCTFBSendButton = (0, react_native_1.requireNativeComponent)('RCTFBSendButton');
+exports.default = SendButton;

--- a/src/FBSettings.js
+++ b/src/FBSettings.js
@@ -1,0 +1,116 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+const validate_1 = require("./util/validate");
+const react_native_1 = require("react-native");
+const Settings = react_native_1.NativeModules.FBSettings;
+exports.default = {
+    /**
+     * For iOS only, get AdvertiserTrackingEnabled status.
+     * @platform ios
+     */
+    getAdvertiserTrackingEnabled() {
+        if (react_native_1.Platform.OS === 'ios') {
+            return Settings.getAdvertiserTrackingEnabled();
+        }
+        else {
+            return Promise.resolve(true);
+        }
+    },
+    /**
+     * For iOS only, set AdvertiserTrackingEnabled status, only works in iOS 14 and above.
+     * @platform ios
+     */
+    setAdvertiserTrackingEnabled(ATE) {
+        if (react_native_1.Platform.OS === 'ios') {
+            return Settings.setAdvertiserTrackingEnabled(ATE);
+        }
+        else {
+            return Promise.resolve(false);
+        }
+    },
+    /**
+     * Set data processing options
+     */
+    setDataProcessingOptions(options, ...args) {
+        let country = 0;
+        if (typeof args[0] === 'number') {
+            country = args[0];
+        }
+        let state = 0;
+        if (typeof args[1] === 'number') {
+            state = args[1];
+        }
+        Settings.setDataProcessingOptions(options, country, state);
+    },
+    /**
+     * Initialize the sdk
+     */
+    initializeSDK() {
+        Settings.initializeSDK();
+    },
+    /**
+     * Set app id
+     */
+    setAppID(appID) {
+        if (!(0, validate_1.isDefined)(appID) || !(0, validate_1.isString)(appID) || appID.length === 0) {
+            throw new Error("setAppID expected 'appID' to be a non empty string");
+        }
+        Settings.setAppID(appID);
+    },
+    /**
+     * Set clientToken
+     */
+    setClientToken(clientToken) {
+        if (!(0, validate_1.isDefined)(clientToken) ||
+            !(0, validate_1.isString)(clientToken) ||
+            clientToken.length === 0) {
+            throw new Error("setClientToken expected 'clientToken' to be a non empty string");
+        }
+        Settings.setClientToken(clientToken);
+    },
+    /**
+     * Sets the Facebook application name for the current app.
+     */
+    setAppName(appName) {
+        if (!(0, validate_1.isDefined)(appName) || !(0, validate_1.isString)(appName) || appName.length === 0) {
+            throw new Error("setAppName expected 'appName' to be a non empty string");
+        }
+        Settings.setAppName(appName);
+    },
+    /**
+     * Sets the Graph API version to use when making Graph requests.
+     */
+    setGraphAPIVersion(version) {
+        if (!(0, validate_1.isDefined)(version) ||
+            !(0, validate_1.isString)(version) ||
+            version.length === 0 ||
+            !(0, validate_1.isValidGraphAPIVersion)(version)) {
+            throw new Error("setGraphAPIVersion expected 'version' to be a non empty string");
+        }
+        Settings.setGraphAPIVersion(version);
+    },
+    /**
+     * Sets whether Facebook SDK should log app events. App events involve eg. app installs,
+     * app launches etc.
+     */
+    setAutoLogAppEventsEnabled(enabled) {
+        Settings.setAutoLogAppEventsEnabled(enabled);
+    },
+    /**
+     * Whether the Facebook SDK should collect advertiser ID properties, like the Apple IDFA
+     * and Android Advertising ID, automatically. Advertiser IDs let you identify and target
+     * specific customers.
+     */
+    setAdvertiserIDCollectionEnabled(enabled) {
+        Settings.setAdvertiserIDCollectionEnabled(enabled);
+    },
+};

--- a/src/FBShareButton.js
+++ b/src/FBShareButton.js
@@ -1,0 +1,54 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const React = __importStar(require("react"));
+const react_native_1 = require("react-native");
+class ShareButton extends React.Component {
+    static defaultProps;
+    render() {
+        return <RCTFBShareButton {...this.props}/>;
+    }
+}
+const styles = react_native_1.StyleSheet.create({
+    defaultButtonStyle: {
+        height: 30,
+        width: 80,
+    },
+});
+ShareButton.defaultProps = {
+    style: styles.defaultButtonStyle,
+};
+const RCTFBShareButton = (0, react_native_1.requireNativeComponent)('RCTFBShareButton');
+exports.default = ShareButton;

--- a/src/FBShareDialog.js
+++ b/src/FBShareDialog.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_native_1 = require("react-native");
+const ShareDialog = react_native_1.NativeModules.FBShareDialog;
+exports.default = {
+    /**
+     * Check if the dialog can be shown.
+     */
+    canShow(shareContent) {
+        return ShareDialog.canShow(shareContent);
+    },
+    /**
+     * Shows the dialog using the specified content.
+     */
+    show(shareContent) {
+        return ShareDialog.show(shareContent);
+    },
+    /**
+     * Sets the mode for the share dialog.
+     */
+    setMode(mode) {
+        ShareDialog.setMode(mode);
+    },
+    /**
+     * Sets whether or not the native share dialog should fail when it encounters a data error.
+     */
+    setShouldFailOnDataError(shouldFailOnDataError) {
+        ShareDialog.setShouldFailOnDataError(shouldFailOnDataError);
+    },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,59 @@
+"use strict";
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AEMReporterIOS = exports.ShareButton = exports.SendButton = exports.LoginButton = exports.ShareDialog = exports.Settings = exports.Profile = exports.MessageDialog = exports.LoginManager = exports.GraphRequestManager = exports.GraphRequest = exports.GameRequestDialog = exports.AppLink = exports.AppEventsLogger = exports.AuthenticationToken = exports.AccessToken = void 0;
+var FBAccessToken_1 = require("./FBAccessToken");
+Object.defineProperty(exports, "AccessToken", { enumerable: true, get: function () { return __importDefault(FBAccessToken_1).default; } });
+var FBAuthenticationToken_1 = require("./FBAuthenticationToken");
+Object.defineProperty(exports, "AuthenticationToken", { enumerable: true, get: function () { return __importDefault(FBAuthenticationToken_1).default; } });
+var FBAppEventsLogger_1 = require("./FBAppEventsLogger");
+Object.defineProperty(exports, "AppEventsLogger", { enumerable: true, get: function () { return __importDefault(FBAppEventsLogger_1).default; } });
+var FBAppLink_1 = require("./FBAppLink");
+Object.defineProperty(exports, "AppLink", { enumerable: true, get: function () { return __importDefault(FBAppLink_1).default; } });
+var FBGameRequestDialog_1 = require("./FBGameRequestDialog");
+Object.defineProperty(exports, "GameRequestDialog", { enumerable: true, get: function () { return __importDefault(FBGameRequestDialog_1).default; } });
+var FBGraphRequest_1 = require("./FBGraphRequest");
+Object.defineProperty(exports, "GraphRequest", { enumerable: true, get: function () { return __importDefault(FBGraphRequest_1).default; } });
+var FBGraphRequestManager_1 = require("./FBGraphRequestManager");
+Object.defineProperty(exports, "GraphRequestManager", { enumerable: true, get: function () { return __importDefault(FBGraphRequestManager_1).default; } });
+var FBLoginManager_1 = require("./FBLoginManager");
+Object.defineProperty(exports, "LoginManager", { enumerable: true, get: function () { return __importDefault(FBLoginManager_1).default; } });
+var FBMessageDialog_1 = require("./FBMessageDialog");
+Object.defineProperty(exports, "MessageDialog", { enumerable: true, get: function () { return __importDefault(FBMessageDialog_1).default; } });
+var FBProfile_1 = require("./FBProfile");
+Object.defineProperty(exports, "Profile", { enumerable: true, get: function () { return __importDefault(FBProfile_1).default; } });
+var FBSettings_1 = require("./FBSettings");
+Object.defineProperty(exports, "Settings", { enumerable: true, get: function () { return __importDefault(FBSettings_1).default; } });
+var FBShareDialog_1 = require("./FBShareDialog");
+Object.defineProperty(exports, "ShareDialog", { enumerable: true, get: function () { return __importDefault(FBShareDialog_1).default; } });
+var FBLoginButton_1 = require("./FBLoginButton");
+Object.defineProperty(exports, "LoginButton", { enumerable: true, get: function () { return __importDefault(FBLoginButton_1).default; } });
+var FBSendButton_1 = require("./FBSendButton");
+Object.defineProperty(exports, "SendButton", { enumerable: true, get: function () { return __importDefault(FBSendButton_1).default; } });
+var FBShareButton_1 = require("./FBShareButton");
+Object.defineProperty(exports, "ShareButton", { enumerable: true, get: function () { return __importDefault(FBShareButton_1).default; } });
+var FBAEMReporter_1 = require("./FBAEMReporter");
+Object.defineProperty(exports, "AEMReporterIOS", { enumerable: true, get: function () { return __importDefault(FBAEMReporter_1).default; } });

--- a/src/models/FBAppGroupCreationContent.js
+++ b/src/models/FBAppGroupCreationContent.js
@@ -1,0 +1,23 @@
+"use strict";
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBGameRequestContent.js
+++ b/src/models/FBGameRequestContent.js
@@ -1,0 +1,23 @@
+"use strict";
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBSDKCallback.js
+++ b/src/models/FBSDKCallback.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBShareContent.js
+++ b/src/models/FBShareContent.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBShareLinkContent.js
+++ b/src/models/FBShareLinkContent.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBSharePhoto.js
+++ b/src/models/FBSharePhoto.js
@@ -1,0 +1,23 @@
+"use strict";
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBSharePhotoContent.js
+++ b/src/models/FBSharePhotoContent.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBShareVideo.js
+++ b/src/models/FBShareVideo.js
@@ -1,0 +1,23 @@
+"use strict";
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @format
+ */
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/models/FBShareVideoContent.js
+++ b/src/models/FBShareVideoContent.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -1,0 +1,164 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.objectKeyValuesAreStrings = objectKeyValuesAreStrings;
+exports.isNull = isNull;
+exports.isObject = isObject;
+exports.isDate = isDate;
+exports.isFunction = isFunction;
+exports.isString = isString;
+exports.isNumber = isNumber;
+exports.isFinite = isFinite;
+exports.isInteger = isInteger;
+exports.isBoolean = isBoolean;
+exports.isArray = isArray;
+exports.isUndefined = isUndefined;
+exports.isDefined = isDefined;
+exports.isAlphaNumericUnderscore = isAlphaNumericUnderscore;
+exports.isValidUrl = isValidUrl;
+exports.isValidGraphAPIVersion = isValidGraphAPIVersion;
+exports.isOneOf = isOneOf;
+exports.noop = noop;
+/**
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Taken from react-native-firebase: https://github.com/invertase/react-native-firebase/blob/master/packages/app/lib/common/validate.js
+ *
+ * @format
+ */
+const AlphaNumericUnderscore = /^[a-zA-Z0-9_]+$/;
+function objectKeyValuesAreStrings(object) {
+    if (!isObject(object)) {
+        return false;
+    }
+    const entries = Object.entries(object);
+    for (let i = 0; i < entries.length; i++) {
+        const [key, value] = entries[i];
+        if (!isString(key) || !isString(value)) {
+            return false;
+        }
+    }
+    return true;
+}
+/**
+ * Simple is null check.
+ */
+function isNull(value) {
+    return value === null;
+}
+/**
+ * Simple is object check.
+ */
+function isObject(value) {
+    return value
+        ? typeof value === 'object' && !Array.isArray(value) && !isNull(value)
+        : false;
+}
+/**
+ * Simple is date check
+ * https://stackoverflow.com/a/44198641
+ */
+function isDate(value) {
+    // use the global isNaN() and not Number.isNaN() since it will validate an Invalid Date
+    return (!!value &&
+        Object.prototype.toString.call(value) === '[object Date]' &&
+        !isNaN(Number(value)));
+}
+/**
+ * Simple is function check
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+function isFunction(value) {
+    return value ? typeof value === 'function' : false;
+}
+/**
+ * Simple is string check
+ */
+function isString(value) {
+    return typeof value === 'string';
+}
+/**
+ * Simple is number check
+ */
+function isNumber(value) {
+    return typeof value === 'number';
+}
+/**
+ * Simple finite check
+ */
+function isFinite(value) {
+    return Number.isFinite(value);
+}
+/**
+ * Simple integer check
+ */
+function isInteger(value) {
+    return Number.isInteger(value);
+}
+/**
+ * Simple is boolean check
+ */
+function isBoolean(value) {
+    return typeof value === 'boolean';
+}
+/**
+ * Simple is array check
+ */
+function isArray(value) {
+    return Array.isArray(value);
+}
+/**
+ * Simple is undefined check
+ */
+function isUndefined(value) {
+    return typeof value === 'undefined';
+}
+/**
+ * Simple is not null nor undefined check
+ */
+function isDefined(value) {
+    return !isNull(value) && !isUndefined(value);
+}
+/**
+ * /^[a-zA-Z0-9_]+$/
+ */
+function isAlphaNumericUnderscore(value) {
+    return AlphaNumericUnderscore.test(value);
+}
+/**
+ * URL test
+ */
+const IS_VALID_URL_REGEX = /^(http|https):\/\/[^ "]+$/;
+function isValidUrl(url) {
+    return IS_VALID_URL_REGEX.test(url);
+}
+/**
+ * Matches Graph API versions of the form v2.7
+ */
+const IS_VALID_GRAPH_API_VERSION = /^(v([0-9]+).([0-9]+))/;
+function isValidGraphAPIVersion(version) {
+    return IS_VALID_GRAPH_API_VERSION.test(version);
+}
+/**
+ * Array includes
+ */
+function isOneOf(value, oneOf = []) {
+    if (!isArray(oneOf)) {
+        return false;
+    }
+    return oneOf.includes(value);
+}
+function noop() {
+    // noop-🐈
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });


### PR DESCRIPTION
Fixes #661

## Problem
React Native 0.77+ (Expo SDK 53+) switched from `AppDelegate.mm` (Objective-C)
to `AppDelegate.swift`. The config plugin had no `withAppDelegate` modifier at all,
so Facebook SDK was never initialized in the native AppDelegate.

Users who manually followed the README instructions for Swift got build errors:

- `incorrect argument label in call (have '_:didFinishLaunchingWithOptions:', expected '_:continue:')`
- `cannot convert value of type '[UIApplication.LaunchOptionsKey : Any]?' to expected argument type 'NSUserActivity'`
- `extra arguments at positions #3, #4 in call`

## Solution
Added `withFacebookAppDelegate.ts` which uses `config.modResults.language` 
(provided by `withAppDelegate` from `@expo/config-plugins`) to detect whether 
the project uses Swift or Objective-C and injects the correct code for each:

- **Swift path**: injects `import FBSDKCoreKit`, SDK init in `didFinishLaunchingWithOptions`, and `openURL` override
- **ObjC path**: injects existing ObjC headers and `FBSDKApplicationDelegate` init

## Testing
- Tested with Expo SDK 54, React Native 0.81 (Swift AppDelegate) ✅
- ObjC path unchanged for RN <= 0.76 ✅

## Related
- Issue #661