### PR TITLE
fix(ios): update FBSDK AppDelegate calls for v17 APIs

### DIFF
--- a/ios/ExpoAdapterFBSDKNext/FacebookAppDelegate.swift
+++ b/ios/ExpoAdapterFBSDKNext/FacebookAppDelegate.swift
@@ -3,10 +3,7 @@ import FBSDKCoreKit
 
 public class FacebookAppDelegate: ExpoAppDelegateSubscriber {
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    ApplicationDelegate.shared.application(
-      application,
-      didFinishLaunchingWithOptions: launchOptions
-    )
+    ApplicationDelegate.shared.initializeSDK()
     return true
   }
 
@@ -14,8 +11,7 @@ public class FacebookAppDelegate: ExpoAppDelegateSubscriber {
     return ApplicationDelegate.shared.application(
       application,
       open: url,
-      sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
-      annotation: options[UIApplication.OpenURLOptionsKey.annotation]
+      options: options
     )
   }
 }


### PR DESCRIPTION
### Motivation

iOS builds are currently failing for Expo/React Native projects using `react-native-fbsdk-next@13.4.3` because `FacebookAppDelegate.swift` still calls legacy `ApplicationDelegate` APIs that were removed in Facebook iOS SDK v17.

This causes Swift compile errors during iOS builds (including EAS), blocking affected projects from building successfully.

Fixes #668

### Description

This PR updates `ios/ExpoAdapterFBSDKNext/FacebookAppDelegate.swift` to use FBSDK v17-compatible APIs:

- Replaces the removed launch call:
  - `ApplicationDelegate.shared.application(_:didFinishLaunchingWithOptions:)`
- With:
  - `ApplicationDelegate.shared.initializeSDK()`

- Updates URL handling to the current signature:
  - `ApplicationDelegate.shared.application(_:open:options:)`
  - Removes deprecated `sourceApplication` / `annotation` forwarding and passes `options` directly.

These changes align the Expo adapter with FBSDK v17 and resolve the compile-time API mismatch.

### Test Plan

I verified the change with the following steps:

1. Use an Expo SDK 53 project with `react-native-fbsdk-next@13.4.3`.
2. Install dependencies and generate native iOS project files (prebuild if needed).
3. Run an iOS build (local or EAS).
4. Confirm `FacebookAppDelegate.swift` compiles successfully and the previous Swift errors are no longer present.
5. Verify URL/deep-link handling still routes through `ApplicationDelegate.shared.application(_:open:options:)`.

**Expected result:**
- iOS build completes successfully without FBSDK delegate signature errors.
- Facebook SDK initialization and URL handling continue to function correctly.