### PR TITLE
feat(android): bridge Limited Login AuthenticationToken via LoginConfiguration

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAuthenticationTokenModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAuthenticationTokenModule.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * Expose AuthenticationToken on Android to mirror iOS FBAuthenticationToken.
+ * Previously only iOS bridged this module; Android JS getters returned null.
+ */
+
+package com.facebook.reactnative.androidsdk;
+
+import com.facebook.AuthenticationToken;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.module.annotations.ReactModule;
+
+/**
+ * Native module that exposes the current Facebook {@link AuthenticationToken} (OIDC JWT)
+ * to JavaScript, matching the iOS {@code FBAuthenticationToken} module API.
+ */
+@ReactModule(name = FBAuthenticationTokenModule.NAME)
+public class FBAuthenticationTokenModule extends ReactContextBaseJavaModule {
+
+    public static final String NAME = "FBAuthenticationToken";
+
+    /**
+     * @param reactContext React application context
+     */
+    public FBAuthenticationTokenModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    /**
+     * Returns the current AuthenticationToken map or null via callback (iOS-compatible shape).
+     *
+     * @param callback Invoked with a single argument: token map or null
+     */
+    @ReactMethod
+    public void getAuthenticationToken(Callback callback) {
+        AuthenticationToken current = AuthenticationToken.getCurrentAuthenticationToken();
+        if (current == null) {
+            callback.invoke((Object) null);
+            return;
+        }
+        WritableMap map = Arguments.createMap();
+        map.putString("authenticationToken", current.getToken());
+        String nonce = current.getExpectedNonce();
+        if (nonce != null) {
+            map.putString("nonce", nonce);
+        }
+        map.putString("graphDomain", "facebook");
+        callback.invoke(map);
+    }
+}

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -173,25 +173,17 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
     }
 
     /**
-     * Classic Facebook login (AccessToken only). Kept for API compatibility.
-     *
-     * @param permissions Facebook permissions
-     * @param promise Promise for login result
-     */
-    @ReactMethod
-    public void logInWithPermissions(ReadableArray permissions, final Promise promise) {
-        logInWithPermissions(permissions, "enabled", null, promise);
-    }
-
-    /**
      * Facebook login with optional Limited Login / OIDC tracking.
      * When {@code loginTracking} is {@code "limited"} or a non-empty {@code nonce} is provided,
      * uses {@link LoginConfiguration} (adds {@code openid} + nonce) so
      * {@link LoginResult#getAuthenticationToken()} can return a JWT.
      * Android SDK has no {@code LoginTracking.LIMITED} enum; LoginConfiguration+nonce is the OIDC path.
      *
+     * Single {@code @ReactMethod} only: TurboModule interop rejects overloaded method names.
+     * JS must always pass loginTracking and nonce (null/undefined for classic AccessToken login).
+     *
      * @param permissions Facebook permissions (email, public_profile, ...)
-     * @param loginTracking {@code "limited"} for OIDC AuthenticationToken, or {@code "enabled"} for classic
+     * @param loginTracking {@code "limited"} for OIDC AuthenticationToken, or {@code "enabled"}/null for classic
      * @param nonce Ceremony-binding nonce for OIDC; may be null/empty for classic
      * @param promise Promise resolved with grantedPermissions and optionally authenticationToken+nonce
      */

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -16,6 +16,10 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Android Limited Login / OIDC: classic logIn(permissions) ignored JS "limited"+nonce
+ * and discarded LoginResult.getAuthenticationToken(). This uses LoginConfiguration
+ * (openid + nonce) and bridges authenticationToken+nonce to JS.
  */
 
 package com.facebook.reactnative.androidsdk;
@@ -23,8 +27,10 @@ package com.facebook.reactnative.androidsdk;
 import android.app.Activity;
 
 import com.facebook.AccessToken;
+import com.facebook.AuthenticationToken;
 import com.facebook.login.DefaultAudience;
 import com.facebook.login.LoginBehavior;
+import com.facebook.login.LoginConfiguration;
 import com.facebook.login.LoginManager;
 import com.facebook.login.LoginResult;
 import com.facebook.react.bridge.Arguments;
@@ -37,6 +43,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -48,23 +55,59 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
 
     public static final String NAME = "FBLoginManager";
 
+    /**
+     * Callback that resolves login results including OIDC AuthenticationToken when present.
+     */
     private class LoginManagerCallback extends ReactNativeFacebookSDKCallback<LoginResult> {
 
-        public LoginManagerCallback(Promise promise) {
+        private final String mExpectedNonce;
+
+        /**
+         * @param promise Promise to resolve/reject for the JS caller
+         * @param expectedNonce Nonce from LoginConfiguration (may be null for classic login)
+         */
+        public LoginManagerCallback(Promise promise, String expectedNonce) {
             super(promise);
+            mExpectedNonce = expectedNonce;
         }
 
         @Override
         public void onSuccess(LoginResult loginResult) {
             if (mPromise != null) {
                 AccessToken accessToken = loginResult.getAccessToken();
-                AccessToken.setCurrentAccessToken(accessToken);
+                if (accessToken != null) {
+                    AccessToken.setCurrentAccessToken(accessToken);
+                }
+
+                AuthenticationToken authenticationToken = loginResult.getAuthenticationToken();
+                if (authenticationToken != null) {
+                    AuthenticationToken.setCurrentAuthenticationToken(authenticationToken);
+                }
+
                 WritableMap result = Arguments.createMap();
                 result.putBoolean("isCancelled", false);
                 result.putArray("grantedPermissions",
                         setToWritableArray(loginResult.getRecentlyGrantedPermissions()));
                 result.putArray("declinedPermissions",
                         setToWritableArray(loginResult.getRecentlyDeniedPermissions()));
+
+                if (authenticationToken != null) {
+                    result.putString("authenticationToken", authenticationToken.getToken());
+                    String resolvedNonce = authenticationToken.getExpectedNonce();
+                    if (resolvedNonce == null || resolvedNonce.isEmpty()) {
+                        resolvedNonce = mExpectedNonce;
+                    }
+                    if (resolvedNonce != null) {
+                        result.putString("nonce", resolvedNonce);
+                    }
+                    result.putString("graphDomain", "facebook");
+                } else {
+                    result.putNull("authenticationToken");
+                    if (mExpectedNonce != null) {
+                        result.putString("nonce", mExpectedNonce);
+                    }
+                }
+
                 mPromise.resolve(result);
                 mPromise = null;
             }
@@ -130,20 +173,63 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
     }
 
     /**
-     * Attempts a Facebook login with the specified permissions.
-     * @param permissions must be one of the provided permissions. See
-     *                    <a href="https://developers.facebook.com/docs/facebook-login/permissions">
-     *                    Facebook login permissions</a>.
-     * @param promise Use promise to pass login result to JS after login finish.
+     * Classic Facebook login (AccessToken only). Kept for API compatibility.
+     *
+     * @param permissions Facebook permissions
+     * @param promise Promise for login result
      */
     @ReactMethod
     public void logInWithPermissions(ReadableArray permissions, final Promise promise) {
+        logInWithPermissions(permissions, "enabled", null, promise);
+    }
+
+    /**
+     * Facebook login with optional Limited Login / OIDC tracking.
+     * When {@code loginTracking} is {@code "limited"} or a non-empty {@code nonce} is provided,
+     * uses {@link LoginConfiguration} (adds {@code openid} + nonce) so
+     * {@link LoginResult#getAuthenticationToken()} can return a JWT.
+     * Android SDK has no {@code LoginTracking.LIMITED} enum; LoginConfiguration+nonce is the OIDC path.
+     *
+     * @param permissions Facebook permissions (email, public_profile, ...)
+     * @param loginTracking {@code "limited"} for OIDC AuthenticationToken, or {@code "enabled"} for classic
+     * @param nonce Ceremony-binding nonce for OIDC; may be null/empty for classic
+     * @param promise Promise resolved with grantedPermissions and optionally authenticationToken+nonce
+     */
+    @ReactMethod
+    public void logInWithPermissions(
+            ReadableArray permissions,
+            String loginTracking,
+            String nonce,
+            final Promise promise) {
         final LoginManager loginManager = LoginManager.getInstance();
-        loginManager.registerCallback(getCallbackManager(), new LoginManagerCallback(promise));
         Activity activity = getCurrentActivity();
-        if (activity != null) {
-            loginManager.logIn(activity,
-                    Utility.reactArrayToStringList(permissions));
+        if (activity == null) {
+            promise.reject("E_NO_ACTIVITY", "Facebook login requires a foreground Activity");
+            return;
+        }
+
+        List<String> permissionList = Utility.reactArrayToStringList(permissions);
+        boolean useOidc =
+                (loginTracking != null && loginTracking.equalsIgnoreCase("limited"))
+                        || (nonce != null && !nonce.isEmpty());
+
+        if (useOidc) {
+            LoginConfiguration configuration;
+            if (nonce != null && !nonce.isEmpty()) {
+                configuration = new LoginConfiguration(permissionList, nonce);
+            } else {
+                configuration = new LoginConfiguration(permissionList);
+            }
+            String expectedNonce = configuration.getNonce();
+            loginManager.registerCallback(
+                    getCallbackManager(),
+                    new LoginManagerCallback(promise, expectedNonce));
+            loginManager.logIn(activity, configuration);
+        } else {
+            loginManager.registerCallback(
+                    getCallbackManager(),
+                    new LoginManagerCallback(promise, null));
+            loginManager.logIn(activity, permissionList);
         }
     }
 
@@ -154,7 +240,7 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
     @ReactMethod
     public void reauthorizeDataAccess(final Promise promise) {
         final LoginManager loginManager = LoginManager.getInstance();
-        loginManager.registerCallback(getCallbackManager(), new LoginManagerCallback(promise));
+        loginManager.registerCallback(getCallbackManager(), new LoginManagerCallback(promise, null));
         Activity activity = getCurrentActivity();
         if (activity != null) {
             loginManager.reauthorizeDataAccess(activity);

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -37,6 +37,7 @@ public class FBSDKPackage implements ReactPackage {
             ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
                 new FBAccessTokenModule(reactContext),
+                new FBAuthenticationTokenModule(reactContext),
                 new FBAppEventsLoggerModule(reactContext),
                 new FBAppLinkModule(reactContext),
                 new FBGameRequestDialogModule(reactContext, mActivityEventListener),

--- a/src/FBAuthenticationToken.ts
+++ b/src/FBAuthenticationToken.ts
@@ -1,7 +1,10 @@
 /**
  * @format
+ *
+ * Cross-platform AuthenticationToken getter.
+ * getAuthenticationTokenIOS remains as an alias for existing call sites.
  */
-import {Platform, NativeModules} from 'react-native';
+import {NativeModules} from 'react-native';
 
 const AuthenticationToken = NativeModules.FBAuthenticationToken;
 
@@ -12,24 +15,27 @@ export type AuthenticationTokenMap = {
 };
 
 /**
- * Represents an immutable access token for using Facebook services.
+ * Represents an immutable authentication token for Facebook Limited Login / OIDC.
  */
 class FBAuthenticationToken {
   /**
-     The raw token string from the authentication response
-    */
+   * The raw token string from the authentication response
+   */
   authenticationToken: string;
 
   /**
-     The nonce from the decoded authentication response
-    */
+   * The nonce from the decoded authentication response
+   */
   nonce: string;
 
   /**
-    The graph domain where the user is authenticated.
+   * The graph domain where the user is authenticated.
    */
   graphDomain: string;
 
+  /**
+   * @param tokenMap Native token map from FBAuthenticationToken module
+   */
   constructor(tokenMap: AuthenticationTokenMap) {
     this.authenticationToken = tokenMap.authenticationToken;
     this.nonce = tokenMap.nonce;
@@ -38,15 +44,17 @@ class FBAuthenticationToken {
   }
 
   /**
-   * Getter for the authentication token
+   * Getter for the current AuthenticationToken (iOS and Android).
+   *
+   * @returns Current token instance or null when Limited Login JWT is unavailable
    */
-  static getAuthenticationTokenIOS() {
-    if (Platform.OS === 'android') {
+  static getAuthenticationToken(): Promise<FBAuthenticationToken | null> {
+    if (!AuthenticationToken || typeof AuthenticationToken.getAuthenticationToken !== 'function') {
       return Promise.resolve(null);
     }
     return new Promise<FBAuthenticationToken | null>((resolve) => {
       AuthenticationToken.getAuthenticationToken(
-        (tokenMap: AuthenticationTokenMap) => {
+        (tokenMap: AuthenticationTokenMap | null) => {
           if (tokenMap) {
             resolve(new FBAuthenticationToken(tokenMap));
           } else {
@@ -55,6 +63,16 @@ class FBAuthenticationToken {
         },
       );
     });
+  }
+
+  /**
+   * iOS-named alias for {@link getAuthenticationToken}. Kept so existing call sites
+   * and iOS behavior remain stable after the cross-platform patch.
+   *
+   * @returns Current token instance or null
+   */
+  static getAuthenticationTokenIOS(): Promise<FBAuthenticationToken | null> {
+    return FBAuthenticationToken.getAuthenticationToken();
   }
 }
 

--- a/src/FBLoginManager.ts
+++ b/src/FBLoginManager.ts
@@ -18,6 +18,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * @format
+ *
+ * Pass limited+nonce on Android (previously iOS-only).
  */
 import {RNFBSDKCallback} from './models/FBSDKCallback';
 import {NativeModules, Platform} from 'react-native';
@@ -53,10 +55,14 @@ export type LoginBehaviorIOS =
   'browser';
 /**
  * Shows the results of a login operation.
+ * Android OIDC login may also return authenticationToken + nonce.
  */
 export type LoginResult = RNFBSDKCallback & {
   grantedPermissions?: Array<string>;
   declinedPermissions?: Array<string>;
+  authenticationToken?: string | null;
+  nonce?: string;
+  graphDomain?: string;
 };
 
 export type LoginTracking = 'enabled' | 'limited';
@@ -64,22 +70,20 @@ export type LoginTracking = 'enabled' | 'limited';
 export default {
   /**
    * Log in with the requested permissions.
-   * @param loginTrackingIOS IOS only: loginTracking: 'enabled' | 'limited', default 'enabled'.
-   * @param nonceIOS IOS only: Nonce that the configuration was created with. A unique nonce will be used if none is provided to the factory method.
+   * @param loginTracking loginTracking: 'enabled' | 'limited', default 'enabled'.
+   *   On Android, 'limited' (or a nonce) uses LoginConfiguration (openid + OIDC JWT).
+   * @param nonce Nonce for Limited Login / OIDC; a unique nonce is used if omitted on native SDK.
    */
   logInWithPermissions(
     permissions: Array<string>,
-    loginTrackingIOS?: LoginTracking,
-    nonceIOS?: string,
+    loginTracking?: LoginTracking,
+    nonce?: string,
   ): Promise<LoginResult> {
-    if (Platform.OS === 'ios') {
-      return LoginManager.logInWithPermissions(
-        permissions,
-        loginTrackingIOS,
-        nonceIOS,
-      );
-    }
-    return LoginManager.logInWithPermissions(permissions);
+    return LoginManager.logInWithPermissions(
+      permissions,
+      loginTracking,
+      nonce,
+    );
   },
 
   /**

--- a/src/FBLoginManager.ts
+++ b/src/FBLoginManager.ts
@@ -79,10 +79,12 @@ export default {
     loginTracking?: LoginTracking,
     nonce?: string,
   ): Promise<LoginResult> {
+    // Always pass tracking+nonce so Android has a single @ReactMethod arity
+    // (TurboModule rejects overloaded native method names).
     return LoginManager.logInWithPermissions(
       permissions,
-      loginTracking,
-      nonce,
+      loginTracking ?? null,
+      nonce ?? null,
     );
   },
 


### PR DESCRIPTION
## Summary
- Android `logInWithPermissions` previously ignored JS `loginTracking`/`nonce` and only returned `AccessToken`, so Limited Login / OIDC JWT (`AuthenticationToken`) was unavailable on Android while iOS worked.
- When `limited` or a nonce is provided, use Facebook Android `LoginConfiguration` (adds `openid` + nonce) and bridge `LoginResult.getAuthenticationToken()` to JS (`authenticationToken`, `nonce`).
- Add Android `FBAuthenticationToken` native module matching iOS; expose cross-platform `getAuthenticationToken()` and keep `getAuthenticationTokenIOS` as an alias.
- Pass `limited`+`nonce` from the shared JS `LoginManager` API on Android (no longer iOS-only).

## Test plan
- [ ] Android: `LoginManager.logInWithPermissions(['public_profile','email'], 'limited', nonce)` resolves with a 3-segment JWT in `authenticationToken` (when Meta returns one)
- [ ] Android: `AuthenticationToken.getAuthenticationToken()` / `getAuthenticationTokenIOS()` returns the current token after login
- [ ] Classic path (`enabled` / no nonce) still returns AccessToken permissions result
- [ ] iOS Limited Login unchanged (regression smoke)


Made with [Cursor](https://cursor.com)