### PR TITLE
fix(graph)!: isolate batches and preserve native Graph responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,24 +950,36 @@ import { GraphRequest, GraphRequestManager } from 'react-native-fbsdk-next';
 // ...
 
 // Create response callback.
-_responseInfoCallback(error, result) {
+function responseInfoCallback(error, result) {
   if (error) {
     console.log("Error fetching data: " + error.toString());
   } else {
-    console.log("Success fetching data: " + result.toString());
+    console.log("Success fetching data: " + JSON.stringify(result));
   }
 }
 
 // Create a graph request asking for user information with a callback to handle the response.
 const infoRequest = new GraphRequest(
   "/me",
-  null,
-  this._responseInfoCallback,
+  {},
+  responseInfoCallback,
 );
 
 // Start the graph request.
 new GraphRequestManager().addRequest(infoRequest).start();
 ```
+
+`start(timeout)` accepts milliseconds on Android and iOS. Omit it or pass `0`
+to retain the native SDK default. Explicit timeouts must be integers from `0`
+to `2147483647`; invalid values throw before starting a request. iOS now honors
+positive timeouts, which were previously ignored.
+Calling `start()` without adding a request also throws instead of leaving an
+empty native batch pending indefinitely.
+
+Graph callbacks receive a nullable error and an object, array, or null result.
+The batch callback reports a connection-level outcome; inspect each request's
+error separately. Adding requests or replacing callbacks after `start()` does
+not change the callbacks for the already-started batch.
 
 ## Expo installation
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBGraphRequestModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBGraphRequestModule.java
@@ -21,7 +21,6 @@
 package com.facebook.reactnative.androidsdk;
 
 import android.os.Bundle;
-import android.util.SparseArray;
 
 import com.facebook.AccessToken;
 import com.facebook.FacebookRequestError;
@@ -29,6 +28,7 @@ import com.facebook.GraphRequest;
 import com.facebook.GraphRequestBatch;
 import com.facebook.GraphResponse;
 import com.facebook.HttpMethod;
+import com.facebook.internal.Logger;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -45,7 +45,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.Iterator;
 
 /**
@@ -56,15 +55,13 @@ import java.util.Iterator;
 public class FBGraphRequestModule extends ReactContextBaseJavaModule {
     public static final String NAME = "FBGraphRequest";
 
-    private SparseArray<WritableMap> mResponses;
-
     private class GraphRequestBatchCallback implements GraphRequestBatch.Callback {
 
-        private int mBatchID;
-        private Callback mCallback;
+        private final WritableMap mResponses;
+        private final Callback mCallback;
 
-        public GraphRequestBatchCallback(int batchID, Callback callback) {
-            mBatchID = batchID;
+        public GraphRequestBatchCallback(WritableMap responses, Callback callback) {
+            mResponses = responses;
             mCallback = callback;
         }
 
@@ -72,33 +69,35 @@ public class FBGraphRequestModule extends ReactContextBaseJavaModule {
         public void onBatchCompleted(GraphRequestBatch batch) {
             WritableMap result = Arguments.createMap();
             result.putString("result", "batch finished executing or timed out");
-            mCallback.invoke(null, result, mResponses.get(mBatchID));
-            mResponses.remove(mBatchID);
+            mCallback.invoke(null, result, mResponses);
         }
     }
 
     private class GraphRequestCallback implements GraphRequest.Callback {
 
-        private String mIndex;
-        private int mBatchID;
+        private final String mIndex;
+        private final WritableMap mResponses;
 
-        public GraphRequestCallback(int index, int batchID) {
+        public GraphRequestCallback(int index, WritableMap responses) {
             mIndex = String.valueOf(index);
-            mBatchID = batchID;
+            mResponses = responses;
         }
 
         @Override
         public void onCompleted(GraphResponse response) {
             WritableArray responseArray = Arguments.createArray();
             responseArray.pushMap(buildFacebookRequestError(response.getError()));
-            responseArray.pushMap(buildGraphResponse(response));
-            mResponses.get(mBatchID).putArray(mIndex, responseArray);
+            if (response.getJSONArray() != null) {
+                responseArray.pushArray(convertJSONArray(response.getJSONArray()));
+            } else {
+                responseArray.pushMap(buildGraphResponse(response));
+            }
+            mResponses.putArray(mIndex, responseArray);
         }
     }
 
     public FBGraphRequestModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        mResponses = new SparseArray<WritableMap>();
     }
 
     @Override
@@ -115,21 +114,14 @@ public class FBGraphRequestModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void start(ReadableArray requestBatch, int timeout, Callback batchCallback) {
         GraphRequestBatch batch = new GraphRequestBatch();
-        int potentialID = 0;
-        int batchID = 0;
-        synchronized (this) {
-            do {
-                batchID = potentialID++;
-            } while (mResponses.get(batchID) != null);
-            mResponses.put(batchID, Arguments.createMap());
-        }
+        WritableMap responses = Arguments.createMap();
         for (int i = 0; i < requestBatch.size(); i++) {
             GraphRequest request = buildRequest(requestBatch.getMap(i));
-            request.setCallback(new GraphRequestCallback(i, batchID));
+            request.setCallback(new GraphRequestCallback(i, responses));
             batch.add(request);
         }
         batch.setTimeout(timeout);
-        GraphRequestBatchCallback callback = new GraphRequestBatchCallback(batchID, batchCallback);
+        GraphRequestBatchCallback callback = new GraphRequestBatchCallback(responses, batchCallback);
         batch.addCallback(callback);
         batch.executeAsync();
     }
@@ -156,17 +148,26 @@ public class FBGraphRequestModule extends ReactContextBaseJavaModule {
             graphRequest.setVersion(configMap.getString("version"));
         }
         if (configMap.hasKey("accessToken")) {
-            graphRequest.setAccessToken(new AccessToken(
-                configMap.getString("accessToken"),
-                AccessToken.getCurrentAccessToken().getApplicationId(),
-                AccessToken.getCurrentAccessToken().getUserId(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null));
+            AccessToken currentToken = AccessToken.getCurrentAccessToken();
+            String token = configMap.getString("accessToken");
+            if (currentToken != null) {
+                graphRequest.setAccessToken(new AccessToken(
+                    token,
+                    currentToken.getApplicationId(),
+                    currentToken.getUserId(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null));
+            } else if (!graphRequest.getParameters().containsKey("access_token")) {
+                // A raw token does not provide the user ID required by AccessToken.
+                // The SDK also accepts an explicit access_token parameter.
+                graphRequest.getParameters().putString("access_token", token);
+                Logger.registerAccessToken(token);
+            }
         } else {
             graphRequest.setAccessToken(AccessToken.getCurrentAccessToken());
         }
@@ -246,8 +247,10 @@ public class FBGraphRequestModule extends ReactContextBaseJavaModule {
                 result.pushInt((int) object);
             } else if (object instanceof Boolean) {
                 result.pushBoolean((Boolean) object);
-            } else if (object instanceof Double) {
-                result.pushDouble((Double) object);
+            } else if (object instanceof Number) {
+                result.pushDouble(((Number) object).doubleValue());
+            } else if (object == JSONObject.NULL) {
+                result.pushNull();
             }
         }
         return result;
@@ -274,8 +277,10 @@ public class FBGraphRequestModule extends ReactContextBaseJavaModule {
                 result.putInt(key, (int) value);
             } else if (value instanceof Boolean) {
                 result.putBoolean(key, (Boolean) value);
-            } else if (value instanceof Double) {
-                result.putDouble(key, (Double) value);
+            } else if (value instanceof Number) {
+                result.putDouble(key, ((Number) value).doubleValue());
+            } else if (value == JSONObject.NULL) {
+                result.putNull(key);
             }
         }
         return result;

--- a/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.h
+++ b/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.h
@@ -34,7 +34,7 @@
 /*!
  @abstract  Initialize the RCTFBSDKGraphRequestConnectionContainer object.
  @param requestBatch  The batch of requests to be sent
- @param timeout   The timeout interval to wait for a response before giving up
+ @param timeout   Timeout in milliseconds; zero preserves the native SDK default.
  @param callback  The connection callback to be invoked when the connection is completed.
                   This callback will carry the responses of requests back to javascript.
  */

--- a/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKGraphRequestConnectionContainer.m
@@ -62,7 +62,6 @@ static NSArray<FBSDKGraphRequest *> *FBSDKGraphRequestArray(id json)
 {
   NSArray<FBSDKGraphRequest *> *_requestBatch;
   RCTResponseSenderBlock _batchCallback;
-  NSInteger _timeout;
   FBSDKGraphRequestConnection *_connection;
   NSMutableDictionary *_response;
 }
@@ -82,7 +81,9 @@ static NSArray<FBSDKGraphRequest *> *FBSDKGraphRequestArray(id json)
     _connection.delegate = self;
     _requestBatch = FBSDKGraphRequestArray(requestBatch);
     _batchCallback = callback;
-    _timeout = timeout;
+    if (timeout > 0) {
+      _connection.timeout = timeout / 1000.0;
+    }
     _response = [[NSMutableDictionary alloc] init];
   }
   return self;
@@ -90,7 +91,9 @@ static NSArray<FBSDKGraphRequest *> *FBSDKGraphRequestArray(id json)
 
 - (void)start
 {
-  g_pendingConnection = [[NSMutableArray alloc] init];
+  if (!g_pendingConnection) {
+    g_pendingConnection = [[NSMutableArray alloc] init];
+  }
   [g_pendingConnection addObject:self];
   for (int i = 0; i < _requestBatch.count; i++) {
     FBSDKGraphRequestCompletion completion = ^(id<FBSDKGraphRequestConnecting> connection, id result, NSError *error) {
@@ -107,17 +110,25 @@ static NSArray<FBSDKGraphRequest *> *FBSDKGraphRequestArray(id json)
 - (void)requestConnectionDidFinishLoading:(FBSDKGraphRequestConnection *)connection
 {
   if (_batchCallback) {
-    _batchCallback(@[[NSNull null], @{@"result": @"success"}, _response]);
+    RCTResponseSenderBlock callback = _batchCallback;
+    _batchCallback = nil;
+    callback(@[[NSNull null], @{@"result": @"success"}, _response]);
   }
+  _connection.delegate = nil;
+  _connection = nil;
   [g_pendingConnection removeObject:self];
 }
 
 - (void)requestConnection:(FBSDKGraphRequestConnection *)connection didFailWithError:(NSError *)error
 {
   if (_batchCallback) {
+    RCTResponseSenderBlock callback = _batchCallback;
+    _batchCallback = nil;
     NSDictionary *errorDict = error ? RCTJSErrorFromNSError(error) : nil;
-    _batchCallback(@[@[RCTNullIfNil(errorDict)], [NSNull null], _response]);
+    callback(@[RCTNullIfNil(errorDict), [NSNull null], _response]);
   }
+  _connection.delegate = nil;
+  _connection = nil;
   [g_pendingConnection removeObject:self];
 }
 

--- a/src/FBGraphRequest.ts
+++ b/src/FBGraphRequest.ts
@@ -21,8 +21,8 @@
  */
 
 export type GraphRequestCallback = (
-  error?: Record<string, unknown>,
-  result?: Record<string, unknown>,
+  error?: Record<string, unknown> | null,
+  result?: Record<string, unknown> | unknown[] | null,
 ) => void;
 export type GraphRequestConfig = {
   /**
@@ -80,9 +80,8 @@ class FBGraphRequest {
    * Adds a string parameter to the request.
    */
   addStringParameter(paramString: string, key: string) {
-    if (this.config != null && this.config.parameters != null) {
-      this.config.parameters[key] = {string: paramString};
-    }
+    this.config.parameters ??= {};
+    this.config.parameters[key] = {string: paramString};
   }
 }
 

--- a/src/FBGraphRequestManager.ts
+++ b/src/FBGraphRequestManager.ts
@@ -19,24 +19,27 @@
  *
  * @format
  */
-import GraphRequest, {GraphRequestParameters} from './FBGraphRequest';
+import GraphRequest, {
+  GraphRequestCallback,
+  GraphRequestParameters,
+} from './FBGraphRequest';
 import {NativeModules} from 'react-native';
 
 const NativeGraphRequestManager = NativeModules.FBGraphRequest;
 
 export type Callback = (
-  error?: Record<string, unknown>,
-  result?: Record<string, unknown>,
+  error?: Record<string, unknown> | null,
+  result?: Record<string, unknown> | null,
 ) => void;
 
 function _verifyParameters(request: GraphRequest) {
   if (request.config?.parameters) {
-    for (const key in request.config.parameters) {
+    for (const key of Object.keys(request.config.parameters)) {
       const param = request.config.parameters[key];
 
       if (
         typeof param === 'object' &&
-        (param as GraphRequestParameters)?.string
+        typeof (param as GraphRequestParameters)?.string === 'string'
       ) {
         continue;
       }
@@ -52,7 +55,7 @@ function _verifyParameters(request: GraphRequest) {
 
 class FBGraphRequestManager {
   requestBatch: Array<GraphRequest> = [];
-  requestCallbacks: Array<Callback | undefined> = [];
+  requestCallbacks: Array<GraphRequestCallback | undefined> = [];
   batchCallback: Callback | null = null;
 
   /**
@@ -70,12 +73,7 @@ class FBGraphRequestManager {
    * Note that invocation of the batch callback does not indicate success of every
    * graph request made, only that the entire batch has finished executing.
    */
-  addBatchCallback(
-    callback: (
-      error?: Record<string, unknown>,
-      result?: Record<string, unknown>,
-    ) => void,
-  ): FBGraphRequestManager {
+  addBatchCallback(callback: Callback): FBGraphRequestManager {
     this.batchCallback = callback;
     return this;
   }
@@ -89,28 +87,46 @@ class FBGraphRequestManager {
    * after the batch time out. This is because detecting network status requires
    * extra permission and it's unncessary for the sdk. Instead, you can use the NetInfo module
    * in react-native to get the network status.
+   * @param timeout Timeout in milliseconds on both platforms. Zero or omission
+   * retains the native SDK default. Must be an integer from 0 to 2147483647.
    */
   start(timeout?: number) {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const that = this;
+    if (
+      timeout !== undefined &&
+      (!Number.isInteger(timeout) || timeout < 0 || timeout > 2147483647)
+    ) {
+      throw new Error('Timeout must be an integer from 0 to 2147483647 ms.');
+    }
+    if (this.requestBatch.length === 0) {
+      throw new Error(
+        'Add at least one graph request before starting a batch.',
+      );
+    }
+    const requestCallbacks = this.requestCallbacks.slice();
+    const batchCallback = this.batchCallback;
     const callback = (
-      error: Record<string, unknown>,
-      result: Record<string, unknown>,
-      response: Array<Array<Record<string, unknown>>>,
+      error: Record<string, unknown> | null,
+      result: Record<string, unknown> | null,
+      response: Record<string, Parameters<GraphRequestCallback>>,
     ) => {
       if (response) {
-        that.requestCallbacks.forEach((innerCallback, index) => {
-          if (innerCallback) {
-            innerCallback(response[index][0], response[index][1]);
+        requestCallbacks.forEach((innerCallback, index) => {
+          const requestResponse = response[index];
+          if (innerCallback && requestResponse) {
+            innerCallback(requestResponse[0], requestResponse[1]);
           }
         });
       }
-      if (that.batchCallback) {
-        that.batchCallback(error, result);
+      if (batchCallback) {
+        batchCallback(error, result);
       }
     };
 
-    NativeGraphRequestManager.start(this.requestBatch, timeout || 0, callback);
+    NativeGraphRequestManager.start(
+      this.requestBatch.slice(),
+      timeout || 0,
+      callback,
+    );
   }
 }
 

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -147,7 +147,7 @@ export function isValidUrl(url: string) {
 /**
  * Matches Graph API versions of the form v2.7
  */
-const IS_VALID_GRAPH_API_VERSION = /^(v([0-9]+).([0-9]+))/;
+const IS_VALID_GRAPH_API_VERSION = /^v[0-9]+\.[0-9]+(?![\s\S])/;
 export function isValidGraphAPIVersion(version: string) {
   return IS_VALID_GRAPH_API_VERSION.test(version);
 }


### PR DESCRIPTION
## Fixes and compatibility

Graph callback types now include nullable errors/results and array results. Explicit timeouts are integer milliseconds on both platforms; iOS previously ignored them. Invalid timeouts and empty batches now throw before entering native code. The graph-version validator now rejects malformed or trailing input.

Preserve the first/empty string parameters, reject non-string values, snapshot in-flight callbacks, handle sparse batch failures, preserve JSON nulls/large integer values and top-level arrays, and remove global Android response bookkeeping. Accept explicit tokens without requiring a current login, preserving SDK token redaction. Keep simultaneous iOS connections alive, release terminal callbacks, and return the error object without an extra array wrapper.

## Verification

- js: 25 focused checks passed.
- android: 5 focused checks passed.
- ios: 5 focused checks passed.

Before: add the first parameter to a request with no parameters, pass an empty-string parameter, append a request/change the callback after start(), or return a sparse native batch error. Verify first/empty parameters are retained, callbacks stay with the started batch, and missing responses do not crash. Native fixtures cover JSON null/Long/array values, explicit tokens without login, overlapping iOS connections, and millisecond conversion.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
