### PR TITLE
fix(profile)!: isolate pending requests and preserve nullable profile fields

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBProfileModule.java
@@ -1,5 +1,8 @@
 package com.facebook.reactnative.androidsdk;
 
+import android.os.Handler;
+import android.os.Looper;
+
 import com.facebook.Profile;
 import com.facebook.ProfileTracker;
 import com.facebook.react.bridge.Callback;
@@ -11,8 +14,8 @@ import com.facebook.react.module.annotations.ReactModule;
 
 import androidx.annotation.NonNull;
 
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This is a {@link NativeModule} that allows JS to use FBSDKProfile info of the current logged user.
@@ -20,7 +23,53 @@ import java.util.TimerTask;
 @ReactModule(name = FBProfileModule.NAME)
 public class FBProfileModule extends ReactContextBaseJavaModule {
     public static final String NAME = "FBProfile";
-    private ProfileTracker mProfileTracker;
+    private final Handler mHandler = new Handler(Looper.getMainLooper());
+    private final Set<ProfileRequest> mPendingRequests = new HashSet<>();
+    private volatile boolean mInvalidated;
+
+    private class ProfileRequest {
+      private final Callback mCallback;
+      private ProfileTracker mTracker;
+      private final Runnable mTimeout = () -> finish(null);
+
+      ProfileRequest(Callback callback) {
+        mCallback = callback;
+      }
+
+      void start() {
+        mPendingRequests.add(this);
+        mTracker = new ProfileTracker() {
+          @Override
+          protected void onCurrentProfileChanged(Profile oldProfile, Profile currentProfile) {
+            mHandler.post(() -> finish(currentProfile));
+          }
+        };
+        mHandler.postDelayed(mTimeout, 30000);
+        // The profile may have arrived between the initial read and registration.
+        Profile currentProfile = Profile.getCurrentProfile();
+        if (currentProfile != null) {
+          finish(currentProfile);
+        }
+      }
+
+      void cancel() {
+        mPendingRequests.remove(this);
+        mHandler.removeCallbacks(mTimeout);
+        if (mTracker != null) {
+          mTracker.stopTracking();
+        }
+      }
+
+      void finish(Profile profile) {
+        if (!mPendingRequests.contains(this)) {
+          return;
+        }
+        cancel();
+        if (!mInvalidated) {
+          mCallback.invoke(profile == null ? null : Utility.profileToReactMap(profile));
+        }
+      }
+    }
 
     public FBProfileModule(ReactApplicationContext reactContext) {
       super(reactContext);
@@ -38,31 +87,36 @@ public class FBProfileModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void getCurrentProfile(final Callback callback) {
-      // Return the profile object as a ReactMap.
-      if (Profile.getCurrentProfile() == null) {
-        final Timer timer = new Timer();
-        synchronized (timer) {
-          timer.schedule(
-            new TimerTask() {
-              @Override
-              public void run() {
-                timer.cancel();
-                callback.invoke();
-              }
-            },
-            30000
-          );
-          mProfileTracker = new ProfileTracker() {
-            @Override
-            protected void onCurrentProfileChanged(Profile oldProfile, Profile currentProfile) {
-              timer.cancel();
-              mProfileTracker.stopTracking();
-              callback.invoke(Utility.profileToReactMap(currentProfile));
-            }
-          };
+      mHandler.post(() -> {
+        if (mInvalidated) {
+          return;
         }
-      } else {
-        callback.invoke(Utility.profileToReactMap(Profile.getCurrentProfile()));
+        Profile currentProfile = Profile.getCurrentProfile();
+        if (currentProfile != null) {
+          callback.invoke(Utility.profileToReactMap(currentProfile));
+        } else {
+          new ProfileRequest(callback).start();
+        }
+      });
+  }
+
+  public void invalidate() {
+    super.invalidate();
+    clearPendingRequests();
+  }
+
+  @SuppressWarnings("removal")
+  public void onCatalystInstanceDestroy() {
+    super.onCatalystInstanceDestroy();
+    clearPendingRequests();
+  }
+
+  private void clearPendingRequests() {
+    mInvalidated = true;
+    mHandler.post(() -> {
+      for (ProfileRequest request : new HashSet<>(mPendingRequests)) {
+        request.cancel();
       }
+    });
   }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/Utility.java
@@ -108,10 +108,10 @@ public final class Utility {
         Utility.putStringOrNull(map, "middleName", middleName);
 
         Uri profilePictureUri = profile.getProfilePictureUri(100, 100);
-        Utility.putStringOrNull(map, "imageURL", profilePictureUri.toString());
+        Utility.putStringOrNull(map, "imageURL", profilePictureUri == null ? null : profilePictureUri.toString());
 
         Uri linkUri = profile.getLinkUri();
-        Utility.putStringOrNull(map, "linkURL", linkUri.toString());
+        Utility.putStringOrNull(map, "linkURL", linkUri == null ? null : linkUri.toString());
 
         String userId = profile.getId();
         Utility.putStringOrNull(map, "userID", userId);

--- a/ios/RCTFBSDK/core/RCTFBSDKProfile.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKProfile.m
@@ -22,36 +22,37 @@ RCT_EXPORT_METHOD(getCurrentProfile:(RCTResponseSenderBlock)callback)
 
 static NSDictionary *RCTBuildProfileDict(void)
 {
-    if (!FBSDKProfile.currentProfile) {
+    FBSDKProfile *profile = FBSDKProfile.currentProfile;
+    if (!profile) {
         return nil;
     }
 
     return @{
-        @"name": FBSDKProfile.currentProfile.name ? FBSDKProfile.currentProfile.name : [NSNull null],
-        @"firstName": FBSDKProfile.currentProfile.firstName ? FBSDKProfile.currentProfile.firstName : [NSNull null],
-        @"lastName": FBSDKProfile.currentProfile.lastName ? FBSDKProfile.currentProfile.lastName : [NSNull null],
-        @"middleName": FBSDKProfile.currentProfile.middleName ? FBSDKProfile.currentProfile.middleName : [NSNull null],
-        @"imageURL": FBSDKProfile.currentProfile.imageURL ? FBSDKProfile.currentProfile.imageURL.relativeString : [NSNull null],
-        @"linkURL": FBSDKProfile.currentProfile.linkURL ? FBSDKProfile.currentProfile.linkURL.relativeString : [NSNull null],
-        @"userID": FBSDKProfile.currentProfile.userID ? FBSDKProfile.currentProfile.userID : [NSNull null],
-        @"email": FBSDKProfile.currentProfile.email ? FBSDKProfile.currentProfile.email : [NSNull null],
-        @"refreshDate": FBSDKProfile.currentProfile.refreshDate ? @(FBSDKProfile.currentProfile.refreshDate.timeIntervalSince1970 * 1000) : [NSNull null],
-        @"friendIDs": FBSDKProfile.currentProfile.friendIDs ? FBSDKProfile.currentProfile.friendIDs : [NSNull null],
-        @"birthday": FBSDKProfile.currentProfile.birthday ? @(FBSDKProfile.currentProfile.birthday.timeIntervalSince1970 * 1000) : [NSNull null],
-        @"ageRange": FBSDKProfile.currentProfile.ageRange ? @{
-            @"min": FBSDKProfile.currentProfile.ageRange.min,
-            @"max": FBSDKProfile.currentProfile.ageRange.max
+        @"name": RCTNullIfNil(profile.name),
+        @"firstName": RCTNullIfNil(profile.firstName),
+        @"lastName": RCTNullIfNil(profile.lastName),
+        @"middleName": RCTNullIfNil(profile.middleName),
+        @"imageURL": RCTNullIfNil(profile.imageURL.relativeString),
+        @"linkURL": RCTNullIfNil(profile.linkURL.relativeString),
+        @"userID": RCTNullIfNil(profile.userID),
+        @"email": RCTNullIfNil(profile.email),
+        @"refreshDate": profile.refreshDate ? @(profile.refreshDate.timeIntervalSince1970 * 1000) : [NSNull null],
+        @"friendIDs": RCTNullIfNil(profile.friendIDs),
+        @"birthday": profile.birthday ? @(profile.birthday.timeIntervalSince1970 * 1000) : [NSNull null],
+        @"ageRange": profile.ageRange ? @{
+            @"min": RCTNullIfNil(profile.ageRange.min),
+            @"max": RCTNullIfNil(profile.ageRange.max)
         } : [NSNull null],
-        @"hometown": FBSDKProfile.currentProfile.hometown ? @{
-            @"id": FBSDKProfile.currentProfile.hometown.id,
-            @"name": FBSDKProfile.currentProfile.hometown.name
+        @"hometown": profile.hometown ? @{
+            @"id": profile.hometown.id,
+            @"name": profile.hometown.name
         } : [NSNull null],
-        @"location": FBSDKProfile.currentProfile.location ? @{
-            @"id": FBSDKProfile.currentProfile.location.id,
-            @"name": FBSDKProfile.currentProfile.location.name
+        @"location": profile.location ? @{
+            @"id": profile.location.id,
+            @"name": profile.location.name
         } : [NSNull null],
-        @"gender": FBSDKProfile.currentProfile.gender ? FBSDKProfile.currentProfile.gender : [NSNull null],
-        @"permissions": FBSDKProfile.currentProfile.permissions ? FBSDKProfile.currentProfile.permissions.allObjects : [NSNull null]
+        @"gender": RCTNullIfNil(profile.gender),
+        @"permissions": RCTNullIfNil(profile.permissions.allObjects)
     };
 }
 

--- a/src/FBProfile.ts
+++ b/src/FBProfile.ts
@@ -17,7 +17,7 @@ export type ProfileMap = {
   refreshDate?: number | null;
   friendIDs?: Array<string> | null;
   birthday?: number | null;
-  ageRange?: {min: number; max: number} | null;
+  ageRange?: {min: number | null; max: number | null} | null;
   hometown?: {id: string; name: string} | null;
   location?: {id: string; name: string} | null;
   gender?: string | null;
@@ -95,7 +95,7 @@ class FBProfile {
    * IMPORTANT: This field will only be populated if your user has granted your application the 'user_age_range' permission and
    * limited login flow is used on iOS
    */
-  ageRange?: {min: number; max: number} | null;
+  ageRange?: {min: number | null; max: number | null} | null;
 
   /**
    * The user’s hometown.
@@ -134,11 +134,11 @@ class FBProfile {
       this.email = profileMap.email;
     }
     this.name = profileMap.name;
-    this.refreshDate = profileMap.refreshDate
-      ? new Date(profileMap.refreshDate)
-      : null;
+    this.refreshDate =
+      profileMap.refreshDate != null ? new Date(profileMap.refreshDate) : null;
     this.friendIDs = profileMap.friendIDs;
-    this.birthday = profileMap.birthday ? new Date(profileMap.birthday) : null;
+    this.birthday =
+      profileMap.birthday != null ? new Date(profileMap.birthday) : null;
     this.ageRange = profileMap.ageRange;
     this.hometown = profileMap.hometown;
     this.location = profileMap.location;


### PR DESCRIPTION
## Fixes and compatibility

The iOS ageRange bounds are now typed as number | null, matching the SDK. Callers must handle null bounds. The existing 30-second Android profile timeout and absent-profile result remain unchanged.

Replace per-request Timer threads and a shared tracker with main-thread, request-local trackers and timeouts. Remove both on completion/invalidation and ignore duplicate/late callbacks. Serialize a single iOS profile snapshot, preserve nullable age bounds and Android URLs, and retain Unix-epoch dates in JavaScript.

## Verification

- android: 7 focused checks passed.
- ios: 4 focused checks passed.
- js: 2 focused checks passed.

Start two profile lookups, deliver a null profile, trigger timeout then a late update, and invalidate while pending. Each callback settles at most once, trackers/timeouts are removed, and null age bounds/URLs plus epoch dates serialize correctly.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
