### PR TITLE
fix(login): settle Android login failures and preserve pending callback ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,11 @@ export default class Login extends Component {
 
 You can also use the Login Manager with custom UI to perform Login.
 
+On Android, await a pending login or reauthorization before starting another.
+Overlapping calls reject with `E_LOGIN_IN_PROGRESS`; a missing foreground
+Activity rejects with `E_NO_ACTIVITY`. `getDefaultAudience()` returns `only_me`
+on both platforms, matching `setDefaultAudience()`.
+
 ```js
 // ...
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginManagerModule.java
@@ -35,6 +35,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.module.annotations.ReactModule;
 
 import java.util.Locale;
@@ -47,16 +48,48 @@ import java.util.Set;
 public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
 
     public static final String NAME = "FBLoginManager";
+    private LoginManagerCallback mPendingLogin;
+    private volatile boolean mInvalidated;
 
     private class LoginManagerCallback extends ReactNativeFacebookSDKCallback<LoginResult> {
+        private final LoginManager mLoginManager;
 
-        public LoginManagerCallback(Promise promise) {
+        public LoginManagerCallback(LoginManager loginManager, Promise promise) {
             super(promise);
+            mLoginManager = loginManager;
+        }
+
+        private boolean finish() {
+            if (mInvalidated || mPendingLogin != this) {
+                return false;
+            }
+            mPendingLogin = null;
+            mLoginManager.unregisterCallback(getCallbackManager());
+            return true;
+        }
+
+        @Override
+        public void onCancel() {
+            if (finish()) {
+                super.onCancel();
+            }
+        }
+
+        @Override
+        public void onError(com.facebook.FacebookException error) {
+            reject(error);
+        }
+
+        void reject(Exception error) {
+            if (finish()) {
+                mPromise.reject(error);
+                mPromise = null;
+            }
         }
 
         @Override
         public void onSuccess(LoginResult loginResult) {
-            if (mPromise != null) {
+            if (finish()) {
                 AccessToken accessToken = loginResult.getAccessToken();
                 AccessToken.setCurrentAccessToken(accessToken);
                 WritableMap result = Arguments.createMap();
@@ -138,13 +171,7 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void logInWithPermissions(ReadableArray permissions, final Promise promise) {
-        final LoginManager loginManager = LoginManager.getInstance();
-        loginManager.registerCallback(getCallbackManager(), new LoginManagerCallback(promise));
-        Activity activity = getCurrentActivity();
-        if (activity != null) {
-            loginManager.logIn(activity,
-                    Utility.reactArrayToStringList(permissions));
-        }
+        startLogin(permissions, false, promise);
     }
 
     /**
@@ -153,12 +180,64 @@ public class FBLoginManagerModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void reauthorizeDataAccess(final Promise promise) {
-        final LoginManager loginManager = LoginManager.getInstance();
-        loginManager.registerCallback(getCallbackManager(), new LoginManagerCallback(promise));
-        Activity activity = getCurrentActivity();
-        if (activity != null) {
-            loginManager.reauthorizeDataAccess(activity);
-        }
+        startLogin(null, true, promise);
+    }
+
+    private void startLogin(ReadableArray permissions, boolean reauthorize, Promise promise) {
+        UiThreadUtil.runOnUiThread(() -> {
+            if (mInvalidated) {
+                return;
+            }
+            if (mPendingLogin != null) {
+                promise.reject("E_LOGIN_IN_PROGRESS", "A Facebook login is already in progress.");
+                return;
+            }
+            Activity activity = getCurrentActivity();
+            if (activity == null) {
+                promise.reject("E_NO_ACTIVITY", "No current activity.");
+                return;
+            }
+            LoginManagerCallback callback = null;
+            try {
+                LoginManager loginManager = LoginManager.getInstance();
+                callback = new LoginManagerCallback(loginManager, promise);
+                mPendingLogin = callback;
+                loginManager.registerCallback(getCallbackManager(), callback);
+                if (reauthorize) {
+                    loginManager.reauthorizeDataAccess(activity);
+                } else {
+                    loginManager.logIn(activity, Utility.reactArrayToStringList(permissions));
+                }
+            } catch (Exception error) {
+                if (callback == null) {
+                    promise.reject(error);
+                } else {
+                    callback.reject(error);
+                }
+            }
+        });
+    }
+
+    public void invalidate() {
+        super.invalidate();
+        clearPendingLogin();
+    }
+
+    @SuppressWarnings("removal")
+    public void onCatalystInstanceDestroy() {
+        super.onCatalystInstanceDestroy();
+        clearPendingLogin();
+    }
+
+    private void clearPendingLogin() {
+        mInvalidated = true;
+        UiThreadUtil.runOnUiThread(() -> {
+            if (mPendingLogin != null) {
+                mPendingLogin.mLoginManager.unregisterCallback(getCallbackManager());
+                mPendingLogin.mPromise = null;
+                mPendingLogin = null;
+            }
+        });
     }
 
     private WritableArray setToWritableArray(Set<String> set) {

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginManager.m
@@ -143,7 +143,7 @@ static NSString *DefaultAudienceToString(FBSDKDefaultAudience defaultAudience)
       result = @"everyone";
       break;
     case FBSDKDefaultAudienceOnlyMe:
-      result = @"only-me";
+      result = @"only_me";
       break;
     default:
       break;


### PR DESCRIPTION
## Fixes and compatibility

Observable corrections: Android rejects E_NO_ACTIVITY / E_LOGIN_IN_PROGRESS instead of leaving or replacing a pending promise. The iOS getter returns only_me rather than only-me. No Limited Login feature is added; this overlaps methods touched by open PR #677 and may require rebasing when that lands.

Run login/reauthorization on the UI thread; reject missing Activity, overlapping requests and synchronous SDK errors. Unregister terminal callbacks, preserve the original request during overlap, and ignore late callbacks after completion/invalidation. Correct the iOS default-audience getter to match its setter.

## Verification

- login: 11 focused checks passed.
- settings-ios: 1 focused checks passed.

Exercise missing Activity, overlapping login/reauthorization, SDK initialization/launch errors, success/cancel/error, late callbacks and invalidation. The original promise remains owned and the next attempt can start after completion.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
