### PR TITLE
fix(dialogs)!: isolate presentations and settle every terminal callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,11 @@ export default class Login extends Component {
 
 All of the dialogs included are used in a similar way, with differing content types.
 
+Only one `show()` call per dialog module can be pending. Await it before opening
+another; overlapping calls reject with `E_DIALOG_IN_PROGRESS`. Success includes
+`isCancelled: false`, but a `postId` is not guaranteed. On Android, calls that
+require an Activity reject with `E_NO_ACTIVITY` when none is available.
+
 ```js
 // ...
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBDialogModule.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.facebook.reactnative.androidsdk;
+
+import android.app.Activity;
+
+import com.facebook.CallbackManager;
+import com.facebook.FacebookCallback;
+import com.facebook.FacebookException;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableMap;
+
+/** Owns the callback and activity listener for one pending dialog. */
+abstract class FBDialogModule extends ReactContextBaseJavaModule {
+    private DialogCallback<?> mPendingDialog;
+    private volatile boolean mInvalidated;
+
+    FBDialogModule(ReactApplicationContext context) {
+        super(context);
+    }
+
+    protected interface DialogAction<RESULT> {
+        void show(Activity activity, CallbackManager manager, FacebookCallback<RESULT> callback);
+    }
+
+    protected interface DialogCheck {
+        boolean canShow(Activity activity);
+    }
+
+    protected final void canShowDialog(Promise promise, DialogCheck check) {
+        UiThreadUtil.runOnUiThread(() -> {
+            if (mInvalidated) {
+                return;
+            }
+            Activity activity = getCurrentActivity();
+            if (activity == null) {
+                promise.reject("E_NO_ACTIVITY", "No current activity.");
+                return;
+            }
+            try {
+                promise.resolve(check.canShow(activity));
+            } catch (Exception error) {
+                promise.reject(error);
+            }
+        });
+    }
+
+    protected abstract class DialogCallback<RESULT> extends ReactNativeFacebookSDKCallback<RESULT> {
+        private FBActivityEventListener mListener;
+
+        DialogCallback(Promise promise) {
+            super(promise);
+        }
+
+        private void dispose() {
+            if (mListener != null) {
+                getReactApplicationContext().removeActivityEventListener(mListener);
+                mListener = null;
+            }
+            mPromise = null;
+        }
+
+        private Promise finish() {
+            if (mInvalidated || mPendingDialog != this) {
+                return null;
+            }
+            mPendingDialog = null;
+            Promise promise = mPromise;
+            dispose();
+            return promise;
+        }
+
+        protected abstract WritableMap buildResult(RESULT result);
+
+        @Override
+        public final void onSuccess(RESULT result) {
+            Promise promise = finish();
+            if (promise != null) {
+                try {
+                    WritableMap value = buildResult(result);
+                    value.putBoolean("isCancelled", false);
+                    promise.resolve(value);
+                } catch (Exception error) {
+                    promise.reject(error);
+                }
+            }
+        }
+
+        @Override
+        public final void onCancel() {
+            Promise promise = finish();
+            if (promise != null) {
+                WritableMap value = Arguments.createMap();
+                value.putBoolean("isCancelled", true);
+                promise.resolve(value);
+            }
+        }
+
+        @Override
+        public final void onError(FacebookException error) {
+            reject(error);
+        }
+
+        private void reject(Exception error) {
+            Promise promise = finish();
+            if (promise != null) {
+                promise.reject(error);
+            }
+        }
+    }
+
+    protected final <RESULT> void showDialog(DialogCallback<RESULT> callback, DialogAction<RESULT> action) {
+        UiThreadUtil.runOnUiThread(() -> {
+            if (mInvalidated) {
+                callback.dispose();
+                return;
+            }
+            if (mPendingDialog != null) {
+                callback.mPromise.reject("E_DIALOG_IN_PROGRESS", "A dialog is already in progress.");
+                callback.dispose();
+                return;
+            }
+            Activity activity = getCurrentActivity();
+            if (activity == null) {
+                callback.mPromise.reject("E_NO_ACTIVITY", "No current activity.");
+                callback.dispose();
+                return;
+            }
+            mPendingDialog = callback;
+            try {
+                callback.mListener = new FBActivityEventListener();
+                getReactApplicationContext().addActivityEventListener(callback.mListener);
+                action.show(activity, callback.mListener.getCallbackManager(), callback);
+            } catch (Exception error) {
+                callback.reject(error);
+            }
+        });
+    }
+
+    @Override
+    public void invalidate() {
+        mInvalidated = true;
+        UiThreadUtil.runOnUiThread(() -> {
+            if (mPendingDialog != null) {
+                mPendingDialog.dispose();
+                mPendingDialog = null;
+            }
+        });
+        super.invalidate();
+    }
+
+    @Override
+    public void onCatalystInstanceDestroy() {
+        invalidate();
+    }
+}

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBGameRequestDialogModule.java
@@ -35,30 +35,33 @@ import com.facebook.gamingservices.GameRequestDialog;
  * See https://developers.facebook.com/docs/games/requests
  */
 @ReactModule(name = FBGameRequestDialogModule.NAME)
-public class FBGameRequestDialogModule extends FBSDKCallbackManagerBaseJavaModule {
+public class FBGameRequestDialogModule extends FBDialogModule {
 
     public static final String NAME = "FBGameRequestDialog";
 
-    private class GameRequestDialogCallback extends ReactNativeFacebookSDKCallback<GameRequestDialog.Result> {
+    private class GameRequestDialogCallback extends DialogCallback<GameRequestDialog.Result> {
 
         public GameRequestDialogCallback(Promise promise) {
             super(promise);
         }
 
         @Override
-        public void onSuccess(GameRequestDialog.Result result) {
-            if (mPromise != null) {
-                WritableMap gameRequestDialogResult = Arguments.createMap();
-                gameRequestDialogResult.putString("requestId", result.getRequestId());
-                gameRequestDialogResult.putArray("to", Utility.listToReactArray(result.getRequestRecipients()));
-                mPromise.resolve(gameRequestDialogResult);
-                mPromise = null;
-            }
+        protected WritableMap buildResult(GameRequestDialog.Result result) {
+            WritableMap gameRequestDialogResult = Arguments.createMap();
+            gameRequestDialogResult.putString("requestId", result.getRequestId());
+            gameRequestDialogResult.putArray("to", Utility.listToReactArray(result.getRequestRecipients()));
+            return gameRequestDialogResult;
         }
     }
 
+    public FBGameRequestDialogModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    /** @deprecated Dialogs now own their activity listener for the duration of each request. */
+    @Deprecated
     public FBGameRequestDialogModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
-        super(reactContext, activityEventListener);
+        this(reactContext);
     }
 
     @Override
@@ -82,13 +85,11 @@ public class FBGameRequestDialogModule extends FBSDKCallbackManagerBaseJavaModul
      */
     @ReactMethod
     public void show(ReadableMap gameRequestContentMap, Promise promise) {
-        if (getCurrentActivity() != null) {
-            GameRequestDialog gameRequestDialog = new GameRequestDialog(getCurrentActivity());
+        showDialog(new GameRequestDialogCallback(promise), (activity, manager, callback) -> {
+            GameRequestDialog gameRequestDialog = new GameRequestDialog(activity);
             GameRequestContent gameRequestContent = Utility.buildGameRequestContent(gameRequestContentMap);
-            gameRequestDialog.registerCallback(getCallbackManager(), new GameRequestDialogCallback(promise));
+            gameRequestDialog.registerCallback(manager, callback);
             gameRequestDialog.show(gameRequestContent);
-        } else {
-            promise.reject("No current activity.");
-        }
+        });
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBMessageDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBMessageDialogModule.java
@@ -34,30 +34,33 @@ import com.facebook.share.widget.MessageDialog;
  * Provides functionality to send content via the Facebook Message Dialog
  */
 @ReactModule(name = FBMessageDialogModule.NAME)
-public class FBMessageDialogModule extends FBSDKCallbackManagerBaseJavaModule {
+public class FBMessageDialogModule extends FBDialogModule {
     public static final String NAME = "FBMessageDialog";
 
-    private class MessageDialogCallback extends ReactNativeFacebookSDKCallback<MessageDialog.Result> {
+    private class MessageDialogCallback extends DialogCallback<MessageDialog.Result> {
 
         public MessageDialogCallback(Promise promise) {
             super(promise);
         }
 
         @Override
-        public void onSuccess(MessageDialog.Result result) {
-            if (mPromise != null) {
-                WritableMap messageDialogResult = Arguments.createMap();
-                messageDialogResult.putString("postId", result.getPostId());
-                mPromise.resolve(messageDialogResult);
-                mPromise = null;
-            }
+        protected WritableMap buildResult(MessageDialog.Result result) {
+            WritableMap messageDialogResult = Arguments.createMap();
+            messageDialogResult.putString("postId", result.getPostId());
+            return messageDialogResult;
         }
     }
 
     private boolean mShouldFailOnDataError;
 
+    public FBMessageDialogModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    /** @deprecated Dialogs now own their activity listener for the duration of each request. */
+    @Deprecated
     public FBMessageDialogModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
-        super(reactContext, activityEventListener);
+        this(reactContext);
     }
 
     @Override
@@ -72,13 +75,11 @@ public class FBMessageDialogModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void canShow(ReadableMap shareContentMap, Promise promise) {
-        if (getCurrentActivity() != null) {
+        canShowDialog(promise, activity -> {
             ShareContent shareContent = Utility.buildShareContent(shareContentMap);
-            MessageDialog messageDialog = new MessageDialog(getCurrentActivity());
-            promise.resolve(messageDialog.canShow(shareContent));
-        } else {
-            promise.reject("No current activity.");
-        }
+            MessageDialog messageDialog = new MessageDialog(activity);
+            return messageDialog.canShow(shareContent);
+        });
     }
 
     /**
@@ -88,15 +89,13 @@ public class FBMessageDialogModule extends FBSDKCallbackManagerBaseJavaModule {
      */
     @ReactMethod
     public void show(ReadableMap shareContentMap, Promise promise) {
-        if (getCurrentActivity() != null) {
+        showDialog(new MessageDialogCallback(promise), (activity, manager, callback) -> {
             ShareContent shareContent = Utility.buildShareContent(shareContentMap);
-            MessageDialog messageDialog = new MessageDialog(getCurrentActivity());
+            MessageDialog messageDialog = new MessageDialog(activity);
             messageDialog.setShouldFailOnDataError(mShouldFailOnDataError);
-            messageDialog.registerCallback(getCallbackManager(), new MessageDialogCallback(promise));
+            messageDialog.registerCallback(manager, callback);
             messageDialog.show(shareContent);
-        } else {
-            promise.reject("No current activity.");
-        }
+        });
     }
 
     /**

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSDKPackage.java
@@ -39,13 +39,13 @@ public class FBSDKPackage implements ReactPackage {
                 new FBAccessTokenModule(reactContext),
                 new FBAppEventsLoggerModule(reactContext),
                 new FBAppLinkModule(reactContext),
-                new FBGameRequestDialogModule(reactContext, mActivityEventListener),
+                new FBGameRequestDialogModule(reactContext),
                 new FBGraphRequestModule(reactContext),
                 new FBLoginManagerModule(reactContext, mActivityEventListener),
-                new FBMessageDialogModule(reactContext, mActivityEventListener),
+                new FBMessageDialogModule(reactContext),
                 new FBProfileModule(reactContext),
                 new FBSettingsModule(),
-                new FBShareDialogModule(reactContext, mActivityEventListener)
+                new FBShareDialogModule(reactContext)
         );
     }
 

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareDialogModule.java
@@ -32,32 +32,35 @@ import com.facebook.share.Sharer;
 import com.facebook.share.widget.ShareDialog;
 
 @ReactModule(name = FBShareDialogModule.NAME)
-public class FBShareDialogModule extends FBSDKCallbackManagerBaseJavaModule {
+public class FBShareDialogModule extends FBDialogModule {
 
     public static final String NAME = "FBShareDialog";
 
-    private class ShareDialogCallback extends ReactNativeFacebookSDKCallback<Sharer.Result> {
+    private class ShareDialogCallback extends DialogCallback<Sharer.Result> {
 
         public ShareDialogCallback(Promise promise) {
             super(promise);
         }
 
         @Override
-        public void onSuccess(Sharer.Result result) {
-            if (mPromise != null) {
-                WritableMap shareResult = Arguments.createMap();
-                shareResult.putString("postId", result.getPostId());
-                mPromise.resolve(shareResult);
-                mPromise = null;
-            }
+        protected WritableMap buildResult(Sharer.Result result) {
+            WritableMap shareResult = Arguments.createMap();
+            shareResult.putString("postId", result.getPostId());
+            return shareResult;
         }
     }
 
     private ShareDialog.Mode mShareDialogMode;
     private boolean mShouldFailOnError;
 
+    public FBShareDialogModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    /** @deprecated Dialogs now own their activity listener for the duration of each request. */
+    @Deprecated
     public FBShareDialogModule(ReactApplicationContext reactContext, FBActivityEventListener activityEventListener) {
-        super(reactContext, activityEventListener);
+        this(reactContext);
     }
 
     @Override
@@ -67,32 +70,26 @@ public class FBShareDialogModule extends FBSDKCallbackManagerBaseJavaModule {
 
     @ReactMethod
     public void canShow(ReadableMap shareContent, Promise promise) {
-        if (getCurrentActivity() != null) {
-            ShareDialog shareDialog = new ShareDialog(getCurrentActivity());
-            promise.resolve(
-                mShareDialogMode == null
+        canShowDialog(promise, activity -> {
+            ShareDialog shareDialog = new ShareDialog(activity);
+            return mShareDialogMode == null
                 ? shareDialog.canShow(Utility.buildShareContent(shareContent))
-                : shareDialog.canShow(Utility.buildShareContent(shareContent), mShareDialogMode)
-            );
-        } else {
-            promise.reject("No current activity.");
-        }
+                : shareDialog.canShow(Utility.buildShareContent(shareContent), mShareDialogMode);
+        });
     }
 
     @ReactMethod
     public void show(ReadableMap shareContent, final Promise promise) {
-        if (getCurrentActivity() != null) {
-            ShareDialog shareDialog = new ShareDialog(getCurrentActivity());
-            shareDialog.registerCallback(getCallbackManager(), new ShareDialogCallback(promise));
+        showDialog(new ShareDialogCallback(promise), (activity, manager, callback) -> {
+            ShareDialog shareDialog = new ShareDialog(activity);
+            shareDialog.registerCallback(manager, callback);
             shareDialog.setShouldFailOnDataError(mShouldFailOnError);
             if (mShareDialogMode != null) {
                 shareDialog.show(Utility.buildShareContent(shareContent), mShareDialogMode);
             } else {
                 shareDialog.show(Utility.buildShareContent(shareContent));
             }
-        } else {
-            promise.reject("No current activity.");
-        }
+        });
     }
 
     @ReactMethod
@@ -101,7 +98,12 @@ public class FBShareDialogModule extends FBSDKCallbackManagerBaseJavaModule {
     }
 
     @ReactMethod
+    public void setShouldFailOnDataError(boolean shouldFailOnDataError) {
+        mShouldFailOnError = shouldFailOnDataError;
+    }
+
+    @ReactMethod
     public void setShouldFailOnError(boolean shouldFailOnError) {
-        mShouldFailOnError = shouldFailOnError;
+        setShouldFailOnDataError(shouldFailOnError);
     }
 }

--- a/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKGameRequestDialog.m
@@ -96,39 +96,61 @@ RCT_EXPORT_METHOD(show:(FBSDKGameRequestContent *)gameRequestContent
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
+  if (_showResolve) {
+    reject(@"E_DIALOG_IN_PROGRESS", @"A game request dialog is already in progress.", nil);
+    return;
+  }
+  _dialog = [[FBSDKGameRequestDialog alloc] initWithContent:gameRequestContent delegate:self];
   _showResolve = resolve;
   _showReject = reject;
-  [_dialog setContent:gameRequestContent];
-  [_dialog show];
+  if (![_dialog show] && _showReject) {
+    _showResolve = nil;
+    _showReject = nil;
+    reject(@"FacebookSDK", @"Game request dialog could not be shown.", nil);
+  }
 }
 
 #pragma mark - FBSDKSharingDelegate
 
 - (void)gameRequestDialog:(FBSDKGameRequestDialog *)gameRequestDialog didCompleteWithResults:(NSDictionary *)results
 {
-  if (_showResolve) {
-    _showResolve(results);
-    _showResolve = nil;
+  if (gameRequestDialog != _dialog) {
+    return;
   }
+  RCTPromiseResolveBlock resolve = _showResolve;
+  _showResolve = nil;
   _showReject = nil;
+  if (resolve) {
+    NSMutableDictionary *result = [results mutableCopy] ?: [NSMutableDictionary new];
+    result[@"isCancelled"] = @NO;
+    resolve(result);
+  }
 }
 
 - (void)gameRequestDialog:(FBSDKGameRequestDialog *)gameRequestDialog didFailWithError:(NSError *)error
 {
-  if (_showReject) {
-    _showReject(@"FacebookSDK", @"Game Request Dialog encounters error.", error);
-    _showReject = nil;
+  if (gameRequestDialog != _dialog) {
+    return;
   }
+  RCTPromiseRejectBlock reject = _showReject;
+  _showReject = nil;
   _showResolve = nil;
+  if (reject) {
+    reject(@"FacebookSDK", @"Game Request Dialog encounters error.", error);
+  }
 }
 
 - (void)gameRequestDialogDidCancel:(FBSDKGameRequestDialog *)gameRequestDialog
 {
-  if (_showResolve) {
-    _showResolve(@{@"isCancelled": @YES});
-    _showResolve = nil;
+  if (gameRequestDialog != _dialog) {
+    return;
   }
+  RCTPromiseResolveBlock resolve = _showResolve;
+  _showResolve = nil;
   _showReject = nil;
+  if (resolve) {
+    resolve(@{@"isCancelled": @YES});
+  }
 }
 
 @end

--- a/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKMessageDialog.m
@@ -58,10 +58,11 @@ RCT_EXPORT_MODULE(FBMessageDialog);
 
 RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  _dialog.shareContent = content;
-  if ([_dialog canShow]) {
+  FBSDKMessageDialog *dialog = [[FBSDKMessageDialog alloc] initWithContent:content delegate:nil];
+  dialog.shouldFailOnDataError = _dialog.shouldFailOnDataError;
+  if ([dialog canShow]) {
     NSError *error;
-    if ([_dialog validateWithError:&error]) {
+    if ([dialog validateWithError:&error]) {
       resolve(@YES);
     } else {
       reject(@"FacebookSDK", @"SharingContent is invalid", error);
@@ -73,10 +74,20 @@ RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseRe
 
 RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
+  if (_showResolve) {
+    reject(@"E_DIALOG_IN_PROGRESS", @"A message dialog is already in progress.", nil);
+    return;
+  }
+  FBSDKMessageDialog *dialog = [[FBSDKMessageDialog alloc] initWithContent:content delegate:self];
+  dialog.shouldFailOnDataError = _dialog.shouldFailOnDataError;
+  _dialog = dialog;
   _showResolve = resolve;
   _showReject = reject;
-  _dialog.shareContent = content;
-  [_dialog show];
+  if (![_dialog show] && _showReject) {
+    _showResolve = nil;
+    _showReject = nil;
+    reject(@"FacebookSDK", @"MessageDialog could not be shown.", nil);
+  }
 }
 
 RCT_EXPORT_METHOD(setShouldFailOnDataError:(BOOL)shouldFailOnDataError)
@@ -88,29 +99,43 @@ RCT_EXPORT_METHOD(setShouldFailOnDataError:(BOOL)shouldFailOnDataError)
 
 - (void)sharer:(id<FBSDKSharing>)sharer didCompleteWithResults:(NSDictionary *)results
 {
-  if (_showResolve) {
-    _showResolve(results);
-    _showResolve = nil;
+  if (sharer != _dialog) {
+    return;
   }
+  RCTPromiseResolveBlock resolve = _showResolve;
+  _showResolve = nil;
   _showReject = nil;
+  if (resolve) {
+    NSMutableDictionary *result = [results mutableCopy] ?: [NSMutableDictionary new];
+    result[@"isCancelled"] = @NO;
+    resolve(result);
+  }
 }
 
 - (void)sharer:(id<FBSDKSharing>)sharer didFailWithError:(NSError *)error
 {
-  if (_showReject) {
-    _showReject(@"FacebookSDK", @"MessageDialog encounters error", error);
-    _showReject = nil;
+  if (sharer != _dialog) {
+    return;
   }
+  RCTPromiseRejectBlock reject = _showReject;
+  _showReject = nil;
   _showResolve = nil;
+  if (reject) {
+    reject(@"FacebookSDK", @"MessageDialog encounters error", error);
+  }
 }
 
 - (void)sharerDidCancel:(id<FBSDKSharing>)sharer
 {
-  if (_showResolve) {
-    _showResolve( @{@"isCancelled": @YES});
-    _showResolve = nil;
+  if (sharer != _dialog) {
+    return;
   }
+  RCTPromiseResolveBlock resolve = _showResolve;
+  _showResolve = nil;
   _showReject = nil;
+  if (resolve) {
+    resolve(@{@"isCancelled": @YES});
+  }
 }
 
 @end

--- a/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
+++ b/ios/RCTFBSDK/share/RCTFBSDKShareDialog.m
@@ -42,6 +42,11 @@ RCT_ENUM_CONVERTER(FBSDKShareDialogMode, (@{
 
 RCT_EXPORT_MODULE(FBShareDialog);
 
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
 #pragma mark - Object Lifecycle
 
 - (instancetype)init
@@ -61,35 +66,40 @@ RCT_EXPORT_MODULE(FBShareDialog);
 
 RCT_EXPORT_METHOD(canShow:(RCTFBSDKSharingContent)content resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  _shareDialog.shareContent = nil;
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if ([self->_shareDialog canShow]) {
-      self->_shareDialog.shareContent = content;
-      NSError *error;
-      if ([self->_shareDialog validateWithError:&error]) {
-        resolve(@YES);
-      } else {
-        reject(@"FacebookSDK", @"SharingContent is invalid", error);
-      }
+  FBSDKShareDialog *dialog = [[FBSDKShareDialog alloc] initWithViewController:nil content:content delegate:nil];
+  dialog.mode = _shareDialog.mode;
+  dialog.shouldFailOnDataError = _shareDialog.shouldFailOnDataError;
+  if ([dialog canShow]) {
+    NSError *error;
+    if ([dialog validateWithError:&error]) {
+      resolve(@YES);
     } else {
-      resolve(@NO);
+      reject(@"FacebookSDK", @"SharingContent is invalid", error);
     }
-  });
+  } else {
+    resolve(@NO);
+  }
 }
 
 RCT_EXPORT_METHOD(show:(RCTFBSDKSharingContent)content
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
+  if (_showResolve) {
+    reject(@"E_DIALOG_IN_PROGRESS", @"A share dialog is already in progress.", nil);
+    return;
+  }
+  FBSDKShareDialog *dialog = [[FBSDKShareDialog alloc] initWithViewController:RCTPresentedViewController() content:content delegate:self];
+  dialog.mode = _shareDialog.mode;
+  dialog.shouldFailOnDataError = _shareDialog.shouldFailOnDataError;
+  _shareDialog = dialog;
   _showResolve = resolve;
   _showReject = reject;
-  _shareDialog.shareContent = content;
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (!self->_shareDialog.fromViewController) {
-      self->_shareDialog.fromViewController = RCTPresentedViewController();
-    }
-    [self->_shareDialog show];
-  });
+  if (![_shareDialog show] && _showReject) {
+    _showResolve = nil;
+    _showReject = nil;
+    reject(@"FacebookSDK", @"ShareDialog could not be shown.", nil);
+  }
 }
 
 RCT_EXPORT_METHOD(setMode:(FBSDKShareDialogMode)mode)
@@ -106,29 +116,43 @@ RCT_EXPORT_METHOD(setShouldFailOnDataError:(BOOL)shouldFailOnDataError)
 
 - (void)sharer:(id<FBSDKSharing>)sharer didCompleteWithResults:(NSDictionary *)results
 {
-  if (_showResolve) {
-    _showResolve(results);
-    _showResolve = nil;
+  if (sharer != _shareDialog) {
+    return;
   }
+  RCTPromiseResolveBlock resolve = _showResolve;
+  _showResolve = nil;
   _showReject = nil;
+  if (resolve) {
+    NSMutableDictionary *result = [results mutableCopy] ?: [NSMutableDictionary new];
+    result[@"isCancelled"] = @NO;
+    resolve(result);
+  }
 }
 
 - (void)sharer:(id<FBSDKSharing>)sharer didFailWithError:(NSError *)error
 {
-  if (_showReject) {
-    _showReject(@"FacebookSDK", @"ShareDialog encounters error", error);
-    _showReject = nil;
+  if (sharer != _shareDialog) {
+    return;
   }
+  RCTPromiseRejectBlock reject = _showReject;
+  _showReject = nil;
   _showResolve = nil;
+  if (reject) {
+    reject(@"FacebookSDK", @"ShareDialog encounters error", error);
+  }
 }
 
 - (void)sharerDidCancel:(id<FBSDKSharing>)sharer
 {
-  if (_showResolve) {
-    _showResolve(@{@"isCancelled": @YES});
-    _showResolve = nil;
+  if (sharer != _shareDialog) {
+    return;
   }
+  RCTPromiseResolveBlock resolve = _showResolve;
+  _showResolve = nil;
   _showReject = nil;
+  if (resolve) {
+    resolve(@{@"isCancelled": @YES});
+  }
 }
 
 @end

--- a/src/FBGameRequestDialog.ts
+++ b/src/FBGameRequestDialog.ts
@@ -26,8 +26,10 @@ import {NativeModules} from 'react-native';
 const GameRequestDialog = NativeModules.FBGameRequestDialog;
 
 export type GameRequestDialogResult = RNFBSDKCallback & {
-  requestId: string;
-  to: Array<string>;
+  requestId?: string;
+  /** The request ID returned by the iOS SDK. */
+  request?: string;
+  to?: Array<string>;
 };
 
 export default {

--- a/src/FBMessageDialog.ts
+++ b/src/FBMessageDialog.ts
@@ -26,7 +26,7 @@ import {NativeModules} from 'react-native';
 const MessageDialog = NativeModules.FBMessageDialog;
 
 export type MessageDialogResult = RNFBSDKCallback & {
-  postId: string;
+  postId?: string | null;
 };
 
 export default {

--- a/src/FBShareDialog.ts
+++ b/src/FBShareDialog.ts
@@ -62,7 +62,7 @@ export type ShareDialogModeIOS =
   | 'native';
 
 export type ShareDialogResult = RNFBSDKCallback & {
-  postId: string;
+  postId?: string | null;
 };
 
 export default {


### PR DESCRIPTION
## Fixes and compatibility

Success results include isCancelled: false. Optional/nullable post IDs and game result fields are accurately typed, including the existing iOS request key. Overlapping presentations reject E_DIALOG_IN_PROGRESS; Android missing Activity rejects E_NO_ACTIVITY. Existing cancellation and native SDK error behavior are retained.

Give Android presentations a request-owned callback manager/activity listener, release it on every terminal path, reject overlapping calls, and catch launch/content errors on the UI thread. Preserve legacy Java constructors and the old ShareDialog setter alias. On iOS, use a fresh dialog and current presenter for each request, isolate canShow from pending content, handle show() returning false, and ignore callbacks from older dialog instances.

## Verification

- dialog-android: 44 focused checks passed.
- dialog-ios: 0 focused checks passed.
- ui-android: 1 focused checks passed.

For all three dialog modules exercise overlap, success/cancel/error, failed presentation, late callbacks and invalidation. Android also covers malformed content and missing Activity. iOS verifies canShow does not overwrite pending content and false show() returns settle exactly once.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
