### PR TITLE
fix(buttons)!: release listeners and handle native prop resets safely

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBLoginButtonManager.java
@@ -31,6 +31,7 @@ import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 
 import java.util.Locale;
+import java.util.Collections;
 
 public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
 
@@ -78,6 +79,8 @@ public class FBLoginButtonManager extends SimpleViewManager<RCTLoginButton> {
     public void setPermissions(
             RCTLoginButton loginButton,
             @Nullable ReadableArray publishPermissions) {
-        loginButton.setPermissions(Utility.reactArrayToStringList(publishPermissions));
+        loginButton.setPermissions(publishPermissions == null
+                ? Collections.emptyList()
+                : Utility.reactArrayToStringList(publishPermissions));
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBSendButtonManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBSendButtonManager.java
@@ -44,8 +44,6 @@ public class FBSendButtonManager extends SimpleViewManager<SendButton> {
     @ReactProp(name = "shareContent")
     public void setShareContent(SendButton sendButton, ReadableMap shareContentMap) {
         ShareContent shareContent = Utility.buildShareContent(shareContentMap);
-        if (shareContent != null) {
-            sendButton.setShareContent(shareContent);
-        }
+        sendButton.setShareContent(shareContent);
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareButtonManager.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBShareButtonManager.java
@@ -46,8 +46,6 @@ public class FBShareButtonManager extends SimpleViewManager<ShareButton> {
     @ReactProp(name = "shareContent")
     public void setShareContent(ShareButton shareButton, ReadableMap shareContentMap) {
         ShareContent shareContent = Utility.buildShareContent(shareContentMap);
-        if (shareContent != null) {
-            shareButton.setShareContent(shareContent);
-        }
+        shareButton.setShareContent(shareContent);
     }
 }

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButton.java
@@ -35,6 +35,7 @@ import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.EventDispatcher;
 
 import java.util.Set;
+import java.lang.ref.WeakReference;
 
 /**
  * A Log In/Log Out button that maintains login state and logs in/out for the app.
@@ -43,18 +44,18 @@ import java.util.Set;
 public class RCTLoginButton extends LoginButton {
 
     private final CallbackManager mCallbackManager;
-    private final EventDispatcher mEventDispatcher;
+    private AccessTokenTracker mAccessTokenTracker;
+    private FacebookCallback<LoginResult> mLoginCallback;
 
     public RCTLoginButton(ThemedReactContext context, CallbackManager callbackManager) {
         super(context);
         this.setToolTipMode(ToolTipMode.NEVER_DISPLAY);
         mCallbackManager = callbackManager;
-        mEventDispatcher = UIManagerHelper.getEventDispatcherForReactTag((ReactContext) getContext(), getId());
         init();
     }
 
     public void init() {
-        new AccessTokenTracker() {
+        mAccessTokenTracker = new AccessTokenTracker() {
             @Override
             protected void onCurrentAccessTokenChanged(
                     AccessToken oldAccessToken,
@@ -62,60 +63,103 @@ public class RCTLoginButton extends LoginButton {
                 if (currentAccessToken == null) {
                     WritableMap event = Arguments.createMap();
                     event.putString("type", "logoutFinished");
-                    ReactContext context = (ReactContext) getContext();
-                    mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
-
+                    dispatchEvent(event);
                 }
             }
         };
-        this.registerCallback(mCallbackManager, new FacebookCallback<LoginResult>() {
-            @Override
-            public void onSuccess(LoginResult loginResult) {
-                WritableMap event = Arguments.createMap();
-                event.putString("type", "loginFinished");
-                event.putString("error", null);
-                WritableMap result = Arguments.createMap();
-                result.putBoolean("isCancelled", false);
-                result.putArray(
-                        "grantedPermissions",
-                        Arguments.fromJavaArgs(
-                                setToStringArray(loginResult.getRecentlyGrantedPermissions())));
-                result.putArray(
-                        "declinedPermissions",
-                        Arguments.fromJavaArgs(
-                                setToStringArray(loginResult.getRecentlyDeniedPermissions())));
-                event.putMap("result", result);
-                ReactContext context = (ReactContext) getContext();
-                mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
-            }
-
-            @Override
-            public void onError(FacebookException error) {
-                WritableMap event = Arguments.createMap();
-                event.putString("type", "loginFinished");
-                event.putString("error", error.toString());
-                WritableMap result = Arguments.createMap();
-                result.putBoolean("isCancelled", false);
-                event.putMap("result", result);
-                ReactContext context = (ReactContext) getContext();
-                mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
-            }
-
-            @Override
-            public void onCancel() {
-                WritableMap event = Arguments.createMap();
-                event.putString("type", "loginFinished");
-                event.putString("error", null);
-                WritableMap result = Arguments.createMap();
-                result.putBoolean("isCancelled", true);
-                event.putMap("result", result);
-                ReactContext context = (ReactContext) getContext();
-                mEventDispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
-            }
-        });
+        mAccessTokenTracker.stopTracking();
+        mLoginCallback = new LoginCallback(this);
+        registerCallback(mCallbackManager, mLoginCallback);
+        // Facebook invokes the external click listener before starting login.
+        // Route the shared callback manager to the button actually pressed.
+        setOnClickListener(view -> registerCallback(mCallbackManager, mLoginCallback));
     }
 
-    private String[] setToStringArray(Set<String> set) {
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        mAccessTokenTracker.startTracking();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        mAccessTokenTracker.stopTracking();
+        super.onDetachedFromWindow();
+    }
+
+    private void dispatchEvent(WritableMap event) {
+        if (getWindowToken() == null) {
+            return;
+        }
+        ReactContext context = (ReactContext) getContext();
+        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
+        if (dispatcher != null) {
+            dispatcher.dispatchEvent(new RCTLoginButtonEvent(UIManagerHelper.getSurfaceId(context), getId(), event));
+        }
+    }
+
+    private static class LoginCallback implements FacebookCallback<LoginResult> {
+        private final WeakReference<RCTLoginButton> mButton;
+
+        LoginCallback(RCTLoginButton button) {
+            mButton = new WeakReference<>(button);
+        }
+
+        @Override
+        public void onSuccess(LoginResult loginResult) {
+            RCTLoginButton button = mButton.get();
+            if (button == null) {
+                return;
+            }
+            WritableMap event = Arguments.createMap();
+            event.putString("type", "loginFinished");
+            event.putString("error", null);
+            WritableMap result = Arguments.createMap();
+            result.putBoolean("isCancelled", false);
+            result.putArray(
+                    "grantedPermissions",
+                    Arguments.fromJavaArgs(
+                            setToStringArray(loginResult.getRecentlyGrantedPermissions())));
+            result.putArray(
+                    "declinedPermissions",
+                    Arguments.fromJavaArgs(
+                            setToStringArray(loginResult.getRecentlyDeniedPermissions())));
+            event.putMap("result", result);
+            button.dispatchEvent(event);
+        }
+
+        @Override
+        public void onError(FacebookException error) {
+            RCTLoginButton button = mButton.get();
+            if (button == null) {
+                return;
+            }
+            WritableMap event = Arguments.createMap();
+            event.putString("type", "loginFinished");
+            event.putString("error", error.toString());
+            WritableMap result = Arguments.createMap();
+            result.putBoolean("isCancelled", false);
+            event.putMap("result", result);
+            button.dispatchEvent(event);
+        }
+
+        @Override
+        public void onCancel() {
+            RCTLoginButton button = mButton.get();
+            if (button == null) {
+                return;
+            }
+            WritableMap event = Arguments.createMap();
+            event.putString("type", "loginFinished");
+            event.putString("error", null);
+            WritableMap result = Arguments.createMap();
+            result.putBoolean("isCancelled", true);
+            event.putMap("result", result);
+            button.dispatchEvent(event);
+        }
+    }
+
+    private static String[] setToStringArray(Set<String> set) {
         String[] array = new String[set.size()];
         int i = 0;
         for (String e : set) {

--- a/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButtonEvent.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/RCTLoginButtonEvent.java
@@ -21,6 +21,11 @@ public class RCTLoginButtonEvent extends Event<RCTLoginButtonEvent> {
     }
 
     @Override
+    public boolean canCoalesce() {
+        return false;
+    }
+
+    @Override
     protected WritableMap getEventData() {
         return mEvent;
     }

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonManager.m
@@ -43,25 +43,22 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(permissions, NSStringArray, RCTFBSDKLoginButtonView)
 {
-    [view.loginButton setPermissions:json ? json : nil];
+    [view.loginButton setPermissions:[RCTConvert NSStringArray:json] ?: defaultView.loginButton.permissions];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(defaultAudience, FBSDKDefaultAudience, RCTFBSDKLoginButtonView)
 {
-    if (json)
-    {
-        [view.loginButton setDefaultAudience:[RCTConvert FBSDKDefaultAudience:json]];
-    }
+    [view.loginButton setDefaultAudience:[RCTConvert FBSDKDefaultAudience:json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(nonceIOS, NSString, RCTFBSDKLoginButtonView)
 {
-    [view.loginButton setNonce:json ? json : nil];
+    [view.loginButton setNonce:[RCTConvert NSString:json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(loginTrackingIOS, NSString, RCTFBSDKLoginButtonView)
 {
-    [view.loginButton setLoginTracking:([json isEqualToString:@"limited"]) ? FBSDKLoginTrackingLimited : FBSDKLoginTrackingEnabled];
+    [view.loginButton setLoginTracking:([[RCTConvert NSString:json] isEqualToString:@"limited"]) ? FBSDKLoginTrackingLimited : FBSDKLoginTrackingEnabled];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(tooltipBehaviorIOS, FBSDKLoginButtonTooltipBehavior, RCTFBSDKLoginButtonView)

--- a/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.m
+++ b/ios/RCTFBSDK/login/RCTFBSDKLoginButtonView.m
@@ -42,7 +42,9 @@
     },
   };
 
-  self.onChange(body);
+  if (self.onChange) {
+    self.onChange(body);
+  }
 }
 
 - (void)loginButtonDidLogOut:(FBSDKLoginButton *)loginButton
@@ -51,7 +53,9 @@
     @"type": @"logoutFinished",
   };
 
-  self.onChange(body);
+  if (self.onChange) {
+    self.onChange(body);
+  }
 }
 
 @end

--- a/src/FBLoginButton.tsx
+++ b/src/FBLoginButton.tsx
@@ -27,14 +27,22 @@ import {
 } from './FBLoginManager';
 import {PropsOf} from './utils';
 import * as React from 'react';
-import {requireNativeComponent, StyleSheet, ViewStyle} from 'react-native';
+import {
+  requireNativeComponent,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
+type LoginButtonError = Record<string, unknown> | string | null;
 export type Event = {
-  nativeEvent?: {
-    type?: 'loginFinished' | 'logoutFinished';
-    error: Record<string, unknown>;
-    result: LoginResult;
-  };
+  nativeEvent?:
+    | {
+        type: 'loginFinished';
+        error: LoginButtonError;
+        result: LoginResult | null;
+      }
+    | {type: 'logoutFinished'};
 };
 export type TooltipBehaviorIOS = 'auto' | 'force_display' | 'disable';
 
@@ -52,8 +60,8 @@ class LoginButton extends React.Component<{
    * The callback invoked upon error/completion of a login request.
    */
   onLoginFinished?: (
-    error: Record<string, unknown>,
-    result: LoginResult,
+    error: LoginButtonError,
+    result: LoginResult | null,
   ) => void;
 
   /**
@@ -94,7 +102,7 @@ class LoginButton extends React.Component<{
   /**
    * View style, if any.
    */
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 
   /**
    * testID, if any.
@@ -105,7 +113,7 @@ class LoginButton extends React.Component<{
     style: typeof styles.defaultButtonStyle;
   };
 
-  _eventHandler(event: Event) {
+  _eventHandler = (event: Event) => {
     if (typeof event !== 'object' || !event || !event.nativeEvent) {
       return;
     }
@@ -119,15 +127,10 @@ class LoginButton extends React.Component<{
         this.props.onLogoutFinished();
       }
     }
-  }
+  };
 
   render() {
-    return (
-      <RCTFBLoginButton
-        {...this.props}
-        onChange={this._eventHandler.bind(this)}
-      />
-    );
+    return <RCTFBLoginButton {...this.props} onChange={this._eventHandler} />;
   }
 }
 

--- a/src/FBLoginManager.ts
+++ b/src/FBLoginManager.ts
@@ -55,8 +55,8 @@ export type LoginBehaviorIOS =
  * Shows the results of a login operation.
  */
 export type LoginResult = RNFBSDKCallback & {
-  grantedPermissions?: Array<string>;
-  declinedPermissions?: Array<string>;
+  grantedPermissions?: Array<string> | null;
+  declinedPermissions?: Array<string> | null;
 };
 
 export type LoginTracking = 'enabled' | 'limited';

--- a/src/FBSendButton.tsx
+++ b/src/FBSendButton.tsx
@@ -22,7 +22,12 @@
 import {ShareContent} from './models/FBShareContent';
 import {PropsOf} from './utils';
 import * as React from 'react';
-import {requireNativeComponent, StyleSheet, ViewStyle} from 'react-native';
+import {
+  requireNativeComponent,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 class SendButton extends React.Component<{
   /**
@@ -33,7 +38,7 @@ class SendButton extends React.Component<{
   /**
    * View style, if any.
    */
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 }> {
   static defaultProps: {
     style: typeof styles.defaultButtonStyle;

--- a/src/FBShareButton.tsx
+++ b/src/FBShareButton.tsx
@@ -22,7 +22,12 @@
 import {ShareContent} from './models/FBShareContent';
 import {PropsOf} from './utils';
 import * as React from 'react';
-import {requireNativeComponent, StyleSheet, ViewStyle} from 'react-native';
+import {
+  requireNativeComponent,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 class ShareButton extends React.Component<{
   /**
@@ -33,7 +38,7 @@ class ShareButton extends React.Component<{
   /**
    * View style, if any.
    */
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 }> {
   static defaultProps: {
     style: typeof styles.defaultButtonStyle;


### PR DESCRIPTION
## Fixes and compatibility

Login callback error/result and canceled permission types now reflect native nullable/string values. Existing strictly narrowed callback annotations may need updating. No change to successful login payload keys or native button appearance.

Stop Android token observation when detached, look up the live event dispatcher/tag, route results to the button actually pressed, and avoid retaining dropped views in SDK callbacks. Keep discrete login events from coalescing. Handle removed permissions/content and iOS null prop resets, guard optional iOS event blocks, reuse the JS handler, and support normal React Native style arrays.

## Verification

- ui-android: 12 focused checks passed.
- settings-ios: 6 focused checks passed.
- js: 1 focused checks passed.

Attach/detach/reattach buttons, assign the tag after construction, remove the dispatcher, press one of two buttons, and deliver a late callback. Verify listener cleanup, routing and discrete events; reset native props/content and exercise nullable callback types.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
