### PR TITLE
fix(events): avoid eager attribution work and guard platform-only token setters

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppEventsLoggerModule.java
@@ -116,7 +116,6 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
     public static final String NAME = "FBAppEventsLogger";
 
     private AppEventsLogger mAppEventLogger;
-    private AttributionIdentifiers mAttributionIdentifiers;
     private ReactApplicationContext mReactContext;
 
     public FBAppEventsLoggerModule(ReactApplicationContext reactContext) {
@@ -126,8 +125,8 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
 
     @Override
     public void initialize() {
+        super.initialize();
         mAppEventLogger = AppEventsLogger.newLogger(mReactContext);
-        mAttributionIdentifiers = AttributionIdentifiers.getAttributionIdentifiers(mReactContext);
     }
 
     @Override
@@ -300,7 +299,8 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      @ReactMethod
      public void getAdvertiserID(Promise promise) {
        try {
-         promise.resolve(mAttributionIdentifiers.getAndroidAdvertiserId());
+         AttributionIdentifiers identifiers = AttributionIdentifiers.getAttributionIdentifiers(mReactContext);
+         promise.resolve(identifiers == null ? null : identifiers.getAndroidAdvertiserId());
        } catch (Exception e) {
          promise.reject("E_ADVERTISER_ID_ERROR", "Can not get advertiserID", e);
        }
@@ -312,7 +312,8 @@ public class FBAppEventsLoggerModule extends ReactContextBaseJavaModule {
      @ReactMethod
      public void getAttributionID(Promise promise) {
        try {
-         promise.resolve(mAttributionIdentifiers.getAttributionId());
+         AttributionIdentifiers identifiers = AttributionIdentifiers.getAttributionIdentifiers(mReactContext);
+         promise.resolve(identifiers == null ? null : identifiers.getAttributionId());
        } catch (Exception e) {
          promise.reject("E_ATTRIBUTION_ID_ERROR", "Can not get attributionID", e);
        }

--- a/src/FBAppEventsLogger.ts
+++ b/src/FBAppEventsLogger.ts
@@ -352,7 +352,9 @@ export default {
    * @platform ios
    */
   setPushNotificationsDeviceToken(deviceToken: string) {
-    AppEventsLogger.setPushNotificationsDeviceToken(deviceToken);
+    if (Platform.OS === 'ios') {
+      AppEventsLogger.setPushNotificationsDeviceToken(deviceToken);
+    }
   },
 
   /**
@@ -360,7 +362,9 @@ export default {
    * @platform Android
    */
   setPushNotificationsRegistrationId(registrationId: string) {
-    AppEventsLogger.setPushNotificationsRegistrationId(registrationId);
+    if (Platform.OS === 'android') {
+      AppEventsLogger.setPushNotificationsRegistrationId(registrationId);
+    }
   },
 
   /**


### PR DESCRIPTION
## Fixes and compatibility

No intended supported-platform API break. Unsupported push-token setters no longer throw a missing-native-method error; unavailable Android identifiers resolve null as documented.

Avoid eager attribution-identifier lookup during Android module initialization. Read current SDK identifier state on demand, resolving null when unavailable. Make platform-specific push-token setters no-ops on the unsupported platform, matching their documented scope.

## Verification

- js: 2 focused checks passed.
- ui-android: 3 focused checks passed.

Initialization must not query attribution identifiers. Later getters use the SDK current state and resolve null when absent. Invoke both push-token setters with only the current platform native method present.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
