### PR TITLE
fix(ios): settle advertiser collection settings and remove duplicate bridge export

### DIFF
--- a/ios/RCTFBSDK/core/RCTFBSDKSettings.m
+++ b/ios/RCTFBSDK/core/RCTFBSDKSettings.m
@@ -33,11 +33,6 @@ RCT_EXPORT_METHOD(setAdvertiserTrackingEnabled:(BOOL)ATE resolver:(RCTPromiseRes
   resolve(@(true)); // true means successfully changed
 }
 
-RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options)
-{
-  [FBSDKSettings.sharedSettings setDataProcessingOptions:options];
-}
-
 RCT_EXPORT_METHOD(setDataProcessingOptions:(nullable NSArray<NSString *> *)options country:(int)country state:(int)state)
 {
   [FBSDKSettings.sharedSettings setDataProcessingOptions:options country:country state:state];
@@ -75,6 +70,7 @@ RCT_EXPORT_METHOD(setAutoLogAppEventsEnabled:(BOOL)enabled)
 RCT_EXPORT_METHOD(setAdvertiserIDCollectionEnabled:(BOOL)enabled resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
   [FBSDKSettings.sharedSettings setIsAdvertiserIDCollectionEnabled:enabled];
+  resolve(nil);
 }
 
 @end


### PR DESCRIPTION
## Fixes and compatibility

No intended API break. The previously unresolved promise now completes, and the existing three-argument processing-options contract is unambiguous.

Resolve the advertiser-ID collection promise after applying the setting and remove the duplicate one-argument setDataProcessingOptions bridge export; JavaScript already sends options, country and state.

## Verification

- settings-ios: 3 focused checks passed.

Await setAdvertiserIDCollectionEnabled and verify one resolution. Confirm a single processing-options bridge export and that country/state are forwarded unchanged.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
