### PR TITLE
fix(android): handle deferred app links without a target URI

### DIFF
--- a/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppLinkModule.java
+++ b/android/src/main/java/com/facebook/reactnative/androidsdk/FBAppLinkModule.java
@@ -20,6 +20,8 @@
 
 package com.facebook.reactnative.androidsdk;
 
+import android.net.Uri;
+
 import com.facebook.applinks.AppLinkData;
 import com.facebook.internal.Utility;
 import com.facebook.react.bridge.Promise;
@@ -58,11 +60,8 @@ public class FBAppLinkModule extends ReactContextBaseJavaModule {
         return new AppLinkData.CompletionHandler() {
             @Override
             public void onDeferredAppLinkDataFetched(AppLinkData appLinkData) {
-                if (appLinkData == null) {
-                    promise.resolve(null);
-                } else {
-                    promise.resolve(appLinkData.getTargetUri().toString());
-                }
+                Uri targetUri = appLinkData == null ? null : appLinkData.getTargetUri();
+                promise.resolve(targetUri == null ? null : targetUri.toString());
             }
         };
     }


### PR DESCRIPTION
## Fixes and compatibility

No intended API break. Missing targets follow the existing null-result contract.

The native SDK can return non-null AppLinkData with a nullable target URI. Snapshot that URI and resolve null when absent instead of throwing from the asynchronous callback.

## Verification

- ui-android: 3 focused checks passed.

Deliver null AppLinkData, data with null target URI, and data with a real URI; expect null, null, and the unchanged URI string.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
