### PR TITLE
fix(expo): preserve native customizations and deduplicate generated configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,6 @@ module.exports = {
   extends: ['plugin:@typescript-eslint/recommended'],
   rules: {
     'prettier/prettier': 0,
+    '@typescript-eslint/no-unused-vars': ['error', {ignoreRestSiblings: true}],
   },
 };

--- a/plugin/build/withFacebookAndroid.js
+++ b/plugin/build/withFacebookAndroid.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setFacebookConfig = exports.withAndroidPermissions = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
+exports.withAndroidPermissions = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
+exports.setFacebookConfig = setFacebookConfig;
 const config_1 = require("./config");
 const config_plugins_1 = require("@expo/config-plugins");
 const { buildResourceItem } = config_plugins_1.AndroidConfig.Resources;
@@ -97,19 +98,32 @@ function getCustomTabActivity() {
     });
 }
 function ensureFacebookActivity({ mainApplication, scheme, }) {
-    if (Array.isArray(mainApplication.activity)) {
-        // Remove all Facebook CustomTabActivities first
-        mainApplication.activity = mainApplication.activity.filter((activity) => {
-            return ![FACEBOOK_ACTIVITY, CUSTOM_TAB_ACTIVITY].includes(activity.$?.['android:name']);
-        });
+    const activities = mainApplication.activity ?? [];
+    mainApplication.activity = activities;
+    if (!scheme) {
+        mainApplication.activity = activities.filter((activity) => ![FACEBOOK_ACTIVITY, CUSTOM_TAB_ACTIVITY].includes(activity.$['android:name']));
+        return mainApplication;
     }
-    else {
-        mainApplication.activity = [];
-    }
-    // If a new scheme is defined, append it to the activity.
-    if (scheme) {
-        mainApplication.activity.push(getFacebookActivity());
-        mainApplication.activity.push(getCustomTabActivity());
+    for (const required of [getFacebookActivity(), getCustomTabActivity()]) {
+        const existing = activities.find((activity) => activity.$['android:name'] === required.$['android:name']);
+        if (!existing) {
+            activities.push(required);
+            continue;
+        }
+        existing.$ = { ...required.$, ...existing.$ };
+        if (required['intent-filter']) {
+            const filters = existing['intent-filter'] ?? [];
+            const hasLoginFilter = filters.some((filter) => filter.data?.some((data) => data.$['android:scheme'] === '@string/fb_login_protocol_scheme') &&
+                filter.action?.some((action) => action.$['android:name'] === 'android.intent.action.VIEW') &&
+                [
+                    'android.intent.category.DEFAULT',
+                    'android.intent.category.BROWSABLE',
+                ].every((name) => filter.category?.some((category) => category.$['android:name'] === name)));
+            if (!hasLoginFilter) {
+                filters.push(...required['intent-filter']);
+            }
+            existing['intent-filter'] = filters;
+        }
     }
     return mainApplication;
 }
@@ -194,4 +208,3 @@ function setFacebookConfig(props, androidManifest) {
     }
     return androidManifest;
 }
-exports.setFacebookConfig = setFacebookConfig;

--- a/plugin/build/withFacebookIOS.d.ts
+++ b/plugin/build/withFacebookIOS.d.ts
@@ -3,12 +3,12 @@ import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
 export declare const withFacebookIOS: ConfigPlugin<ConfigProps>;
 export declare function setFacebookConfig(config: ConfigProps, infoPlist: InfoPlist): InfoPlist;
 export declare function setFacebookScheme(config: ConfigProps, infoPlist: InfoPlist): InfoPlist;
-export declare function setFacebookAutoInitEnabled(config: ConfigProps, { FacebookAutoInitEnabled, ...infoPlist }: InfoPlist): InfoPlist;
-export declare function setFacebookAutoLogAppEventsEnabled(config: ConfigProps, { FacebookAutoLogAppEventsEnabled, ...infoPlist }: InfoPlist): InfoPlist;
-export declare function setFacebookAdvertiserIDCollectionEnabled(config: ConfigProps, { FacebookAdvertiserIDCollectionEnabled, ...infoPlist }: InfoPlist): InfoPlist;
-export declare function setFacebookAppId(config: ConfigProps, { FacebookAppID, ...infoPlist }: InfoPlist): InfoPlist;
-export declare function setFacebookClientToken(config: ConfigProps, { FacebookClientToken, ...infoPlist }: InfoPlist): InfoPlist;
-export declare function setFacebookDisplayName(config: ConfigProps, { FacebookDisplayName, ...infoPlist }: InfoPlist): InfoPlist;
+export declare function setFacebookAutoInitEnabled(config: ConfigProps, { FacebookAutoInitEnabled: _, ...infoPlist }: InfoPlist): InfoPlist;
+export declare function setFacebookAutoLogAppEventsEnabled(config: ConfigProps, { FacebookAutoLogAppEventsEnabled: _, ...infoPlist }: InfoPlist): InfoPlist;
+export declare function setFacebookAdvertiserIDCollectionEnabled(config: ConfigProps, { FacebookAdvertiserIDCollectionEnabled: _, ...infoPlist }: InfoPlist): InfoPlist;
+export declare function setFacebookAppId(config: ConfigProps, { FacebookAppID: _, ...infoPlist }: InfoPlist): InfoPlist;
+export declare function setFacebookClientToken(config: ConfigProps, { FacebookClientToken: _, ...infoPlist }: InfoPlist): InfoPlist;
+export declare function setFacebookDisplayName(config: ConfigProps, { FacebookDisplayName: _, ...infoPlist }: InfoPlist): InfoPlist;
 export declare function setFacebookApplicationQuerySchemes(config: ConfigProps, infoPlist: InfoPlist): InfoPlist;
 export declare const withUserTrackingPermission: ConfigPlugin<{
     iosUserTrackingPermission?: string | false;

--- a/plugin/build/withFacebookIOS.js
+++ b/plugin/build/withFacebookIOS.js
@@ -1,6 +1,15 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withUserTrackingPermission = exports.setFacebookApplicationQuerySchemes = exports.setFacebookDisplayName = exports.setFacebookClientToken = exports.setFacebookAppId = exports.setFacebookAdvertiserIDCollectionEnabled = exports.setFacebookAutoLogAppEventsEnabled = exports.setFacebookAutoInitEnabled = exports.setFacebookScheme = exports.setFacebookConfig = exports.withFacebookIOS = void 0;
+exports.withUserTrackingPermission = exports.withFacebookIOS = void 0;
+exports.setFacebookConfig = setFacebookConfig;
+exports.setFacebookScheme = setFacebookScheme;
+exports.setFacebookAutoInitEnabled = setFacebookAutoInitEnabled;
+exports.setFacebookAutoLogAppEventsEnabled = setFacebookAutoLogAppEventsEnabled;
+exports.setFacebookAdvertiserIDCollectionEnabled = setFacebookAdvertiserIDCollectionEnabled;
+exports.setFacebookAppId = setFacebookAppId;
+exports.setFacebookClientToken = setFacebookClientToken;
+exports.setFacebookDisplayName = setFacebookDisplayName;
+exports.setFacebookApplicationQuerySchemes = setFacebookApplicationQuerySchemes;
 const config_1 = require("./config");
 const config_plugins_1 = require("@expo/config-plugins");
 const { Scheme } = config_plugins_1.IOSConfig;
@@ -24,7 +33,6 @@ function setFacebookConfig(config, infoPlist) {
     infoPlist = setFacebookScheme(config, infoPlist);
     return infoPlist;
 }
-exports.setFacebookConfig = setFacebookConfig;
 function setFacebookScheme(config, infoPlist) {
     const facebookScheme = (0, config_1.getFacebookScheme)(config);
     if (!facebookScheme) {
@@ -35,7 +43,6 @@ function setFacebookScheme(config, infoPlist) {
     }
     return appendScheme(facebookScheme, infoPlist);
 }
-exports.setFacebookScheme = setFacebookScheme;
 function setFacebookAutoInitEnabled(config, { FacebookAutoInitEnabled: _, ...infoPlist }) {
     const isAutoInitEnabled = (0, config_1.getFacebookAutoInitEnabled)(config);
     if (isAutoInitEnabled === null) {
@@ -46,7 +53,6 @@ function setFacebookAutoInitEnabled(config, { FacebookAutoInitEnabled: _, ...inf
         FacebookAutoInitEnabled: isAutoInitEnabled,
     };
 }
-exports.setFacebookAutoInitEnabled = setFacebookAutoInitEnabled;
 function setFacebookAutoLogAppEventsEnabled(config, { FacebookAutoLogAppEventsEnabled: _, ...infoPlist }) {
     const autoLogAppEventsEnabled = (0, config_1.getFacebookAutoLogAppEvents)(config);
     if (autoLogAppEventsEnabled === null) {
@@ -57,7 +63,6 @@ function setFacebookAutoLogAppEventsEnabled(config, { FacebookAutoLogAppEventsEn
         FacebookAutoLogAppEventsEnabled: autoLogAppEventsEnabled,
     };
 }
-exports.setFacebookAutoLogAppEventsEnabled = setFacebookAutoLogAppEventsEnabled;
 function setFacebookAdvertiserIDCollectionEnabled(config, { FacebookAdvertiserIDCollectionEnabled: _, ...infoPlist }) {
     const advertiserIDCollectionEnabled = (0, config_1.getFacebookAdvertiserIDCollection)(config);
     if (advertiserIDCollectionEnabled === null) {
@@ -68,7 +73,6 @@ function setFacebookAdvertiserIDCollectionEnabled(config, { FacebookAdvertiserID
         FacebookAdvertiserIDCollectionEnabled: advertiserIDCollectionEnabled,
     };
 }
-exports.setFacebookAdvertiserIDCollectionEnabled = setFacebookAdvertiserIDCollectionEnabled;
 function setFacebookAppId(config, { FacebookAppID: _, ...infoPlist }) {
     const appID = (0, config_1.getFacebookAppId)(config);
     if (appID) {
@@ -79,7 +83,6 @@ function setFacebookAppId(config, { FacebookAppID: _, ...infoPlist }) {
     }
     return infoPlist;
 }
-exports.setFacebookAppId = setFacebookAppId;
 function setFacebookClientToken(config, { FacebookClientToken: _, ...infoPlist }) {
     const clientToken = (0, config_1.getFacebookClientToken)(config);
     if (clientToken) {
@@ -90,7 +93,6 @@ function setFacebookClientToken(config, { FacebookClientToken: _, ...infoPlist }
     }
     return infoPlist;
 }
-exports.setFacebookClientToken = setFacebookClientToken;
 function setFacebookDisplayName(config, { FacebookDisplayName: _, ...infoPlist }) {
     const facebookDisplayName = (0, config_1.getFacebookDisplayName)(config);
     if (facebookDisplayName) {
@@ -101,34 +103,10 @@ function setFacebookDisplayName(config, { FacebookDisplayName: _, ...infoPlist }
     }
     return infoPlist;
 }
-exports.setFacebookDisplayName = setFacebookDisplayName;
 function setFacebookApplicationQuerySchemes(config, infoPlist) {
     const facebookAppId = (0, config_1.getFacebookAppId)(config);
-    const existingSchemes = infoPlist.LSApplicationQueriesSchemes || [];
-    if (facebookAppId && existingSchemes.includes('fbapi')) {
-        // already included, no need to add again
-        return infoPlist;
-    }
-    else if (!facebookAppId && !existingSchemes.length) {
-        // already removed, no need to strip again
-        const { LSApplicationQueriesSchemes, ...restInfoPlist } = infoPlist;
-        if (LSApplicationQueriesSchemes?.length) {
-            return infoPlist;
-        }
-        else {
-            // Return without the empty LSApplicationQueriesSchemes array.
-            return restInfoPlist;
-        }
-    }
-    // Remove all schemes
-    for (const scheme of fbSchemes) {
-        const index = existingSchemes.findIndex((s) => s === scheme);
-        if (index > -1) {
-            existingSchemes.splice(index, 1);
-        }
-    }
+    const existingSchemes = (infoPlist.LSApplicationQueriesSchemes || []).filter((scheme) => !fbSchemes.includes(scheme));
     if (!facebookAppId) {
-        // Run again to ensure the LSApplicationQueriesSchemes array is stripped if needed.
         infoPlist.LSApplicationQueriesSchemes = existingSchemes;
         if (!infoPlist.LSApplicationQueriesSchemes.length) {
             delete infoPlist.LSApplicationQueriesSchemes;
@@ -144,7 +122,6 @@ function setFacebookApplicationQuerySchemes(config, infoPlist) {
         LSApplicationQueriesSchemes: updatedSchemes,
     };
 }
-exports.setFacebookApplicationQuerySchemes = setFacebookApplicationQuerySchemes;
 const withUserTrackingPermission = (config, { iosUserTrackingPermission } = {}) => {
     if (!iosUserTrackingPermission) {
         return config;

--- a/plugin/build/withSKAdNetworkIdentifiers.js
+++ b/plugin/build/withSKAdNetworkIdentifiers.js
@@ -19,13 +19,17 @@ const withSKAdNetworkIdentifiers = (config, identifiers) => {
         config.ios.infoPlist.SKAdNetworkItems = [];
     }
     // Get ids
-    let existingIds = config.ios.infoPlist.SKAdNetworkItems.map((item) => item?.SKAdNetworkIdentifier ?? null).filter(Boolean);
-    // remove duplicates
-    existingIds = [...new Set(existingIds)];
+    const existingIds = new Set();
+    for (const item of config.ios.infoPlist.SKAdNetworkItems) {
+        if (item?.SKAdNetworkIdentifier) {
+            existingIds.add(item.SKAdNetworkIdentifier);
+        }
+    }
     for (const id of identifiers) {
         // Must be lowercase
         const lower = id.toLowerCase();
-        if (!existingIds.includes(lower)) {
+        if (!existingIds.has(lower)) {
+            existingIds.add(lower);
             config.ios.infoPlist.SKAdNetworkItems.push({
                 SKAdNetworkIdentifier: lower,
             });

--- a/plugin/src/withFacebookAndroid.ts
+++ b/plugin/src/withFacebookAndroid.ts
@@ -145,21 +145,53 @@ function ensureFacebookActivity({
   mainApplication: AndroidConfig.Manifest.ManifestApplication;
   scheme: string | null;
 }) {
-  if (Array.isArray(mainApplication.activity)) {
-    // Remove all Facebook CustomTabActivities first
-    mainApplication.activity = mainApplication.activity.filter((activity) => {
-      return ![FACEBOOK_ACTIVITY, CUSTOM_TAB_ACTIVITY].includes(
-        activity.$?.['android:name'],
-      );
-    });
-  } else {
-    mainApplication.activity = [];
+  const activities = mainApplication.activity ?? [];
+  mainApplication.activity = activities;
+  if (!scheme) {
+    mainApplication.activity = activities.filter(
+      (activity) =>
+        ![FACEBOOK_ACTIVITY, CUSTOM_TAB_ACTIVITY].includes(
+          activity.$['android:name'],
+        ),
+    );
+    return mainApplication;
   }
 
-  // If a new scheme is defined, append it to the activity.
-  if (scheme) {
-    mainApplication.activity.push(getFacebookActivity());
-    mainApplication.activity.push(getCustomTabActivity());
+  for (const required of [getFacebookActivity(), getCustomTabActivity()]) {
+    const existing = activities.find(
+      (activity) => activity.$['android:name'] === required.$['android:name'],
+    );
+    if (!existing) {
+      activities.push(required);
+      continue;
+    }
+    existing.$ = {...required.$, ...existing.$};
+    if (required['intent-filter']) {
+      const filters = existing['intent-filter'] ?? [];
+      const hasLoginFilter = filters.some(
+        (filter) =>
+          filter.data?.some(
+            (data) =>
+              data.$['android:scheme'] === '@string/fb_login_protocol_scheme',
+          ) &&
+          filter.action?.some(
+            (action) =>
+              action.$['android:name'] === 'android.intent.action.VIEW',
+          ) &&
+          [
+            'android.intent.category.DEFAULT',
+            'android.intent.category.BROWSABLE',
+          ].every((name) =>
+            filter.category?.some(
+              (category) => category.$['android:name'] === name,
+            ),
+          ),
+      );
+      if (!hasLoginFilter) {
+        filters.push(...required['intent-filter']);
+      }
+      existing['intent-filter'] = filters;
+    }
   }
   return mainApplication;
 }

--- a/plugin/src/withFacebookIOS.ts
+++ b/plugin/src/withFacebookIOS.ts
@@ -153,32 +153,11 @@ export function setFacebookApplicationQuerySchemes(
 ): InfoPlist {
   const facebookAppId = getFacebookAppId(config);
 
-  const existingSchemes = infoPlist.LSApplicationQueriesSchemes || [];
-
-  if (facebookAppId && existingSchemes.includes('fbapi')) {
-    // already included, no need to add again
-    return infoPlist;
-  } else if (!facebookAppId && !existingSchemes.length) {
-    // already removed, no need to strip again
-    const {LSApplicationQueriesSchemes, ...restInfoPlist} = infoPlist;
-    if (LSApplicationQueriesSchemes?.length) {
-      return infoPlist;
-    } else {
-      // Return without the empty LSApplicationQueriesSchemes array.
-      return restInfoPlist;
-    }
-  }
-
-  // Remove all schemes
-  for (const scheme of fbSchemes) {
-    const index = existingSchemes.findIndex((s) => s === scheme);
-    if (index > -1) {
-      existingSchemes.splice(index, 1);
-    }
-  }
+  const existingSchemes = (infoPlist.LSApplicationQueriesSchemes || []).filter(
+    (scheme) => !fbSchemes.includes(scheme),
+  );
 
   if (!facebookAppId) {
-    // Run again to ensure the LSApplicationQueriesSchemes array is stripped if needed.
     infoPlist.LSApplicationQueriesSchemes = existingSchemes;
     if (!infoPlist.LSApplicationQueriesSchemes.length) {
       delete infoPlist.LSApplicationQueriesSchemes;

--- a/plugin/src/withSKAdNetworkIdentifiers.ts
+++ b/plugin/src/withSKAdNetworkIdentifiers.ts
@@ -22,16 +22,20 @@ export const withSKAdNetworkIdentifiers: ConfigPlugin<string[]> = (
   }
 
   // Get ids
-  let existingIds = config.ios.infoPlist.SKAdNetworkItems.map(
-    (item: any) => item?.SKAdNetworkIdentifier ?? null,
-  ).filter(Boolean) as string[];
-  // remove duplicates
-  existingIds = [...new Set(existingIds)];
+  const existingIds = new Set<string>();
+  for (const item of config.ios.infoPlist.SKAdNetworkItems as Array<{
+    SKAdNetworkIdentifier?: string;
+  } | null>) {
+    if (item?.SKAdNetworkIdentifier) {
+      existingIds.add(item.SKAdNetworkIdentifier);
+    }
+  }
 
   for (const id of identifiers) {
     // Must be lowercase
     const lower = id.toLowerCase();
-    if (!existingIds.includes(lower)) {
+    if (!existingIds.has(lower)) {
+      existingIds.add(lower);
       config.ios.infoPlist.SKAdNetworkItems.push({
         SKAdNetworkIdentifier: lower,
       });


### PR DESCRIPTION
## Fixes and compatibility

No intended API break. Unrelated native configuration is retained. SDK versions and plugin defaults are unchanged; generated declaration/compiler formatting changes are not runtime fixes.

Preserve existing Android activity attributes and intent filters while adding the required callback filter idempotently. Fill partial iOS query-scheme lists and remove all owned duplicates. Deduplicate repeated SKAdNetwork input with a single-pass existing-ID set. Regenerate changed plugin outputs and allow intentional rest-sibling omission in unused-variable linting.

## Verification

- js: 6 focused checks passed.

Run the plugin twice with duplicate SKAdNetwork inputs, partial query-scheme lists, and customized Android activity attributes/intent filters. Verify idempotence and preservation of unrelated metadata.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
