### PR TITLE
fix(example): serialize async actions and handle errors after unmount

### DIFF
--- a/RNFBSDKExample/App.tsx
+++ b/RNFBSDKExample/App.tsx
@@ -40,36 +40,74 @@ const SHARE_LINK_CONTENT: ShareLinkContent = {
 // Possibly only do this for iOS if no need to handle a GDPR-type flow
 Settings.initializeSDK();
 
-export default class App extends Component<{}> {
-  _reauthorizeDataAccess = async () => {
-    try {
-      const result = await LoginManager.reauthorizeDataAccess();
-      Alert.alert(
-        'Reauthorize data access result',
-        JSON.stringify(result, null, 2),
-      );
-    } catch (error) {
-      Alert.alert('Reauthorize data access fail with error:', error as string);
-    }
-  };
+export default class App extends Component<
+  Record<string, never>,
+  {busy: boolean}
+> {
+  state = {busy: false};
+  _busy = false;
+  _mounted = false;
 
-  _shareLinkWithShareDialog = async () => {
-    const canShow = await ShareDialog.canShow(SHARE_LINK_CONTENT);
-    if (canShow) {
-      try {
-        const {isCancelled, postId} = await ShareDialog.show(
-          SHARE_LINK_CONTENT,
+  componentDidMount() {
+    this._mounted = true;
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
+  }
+
+  _runAction = async (action: () => Promise<string>, errorTitle: string) => {
+    if (this._busy || !this._mounted) {
+      return;
+    }
+    this._busy = true;
+    this.setState({busy: true});
+    try {
+      const message = await action();
+      if (this._mounted) {
+        Alert.alert(message);
+      }
+    } catch (error) {
+      if (this._mounted) {
+        Alert.alert(
+          errorTitle,
+          error instanceof Error ? error.message : String(error),
         );
-        if (isCancelled) {
-          Alert.alert('Share cancelled');
-        } else {
-          Alert.alert('Share success with postId: ' + postId);
-        }
-      } catch (error) {
-        Alert.alert('Share fail with error: ' + error);
+      }
+    } finally {
+      this._busy = false;
+      if (this._mounted) {
+        this.setState({busy: false});
       }
     }
   };
+
+  _reauthorizeDataAccess = () =>
+    this._runAction(async () => {
+      const result = await LoginManager.reauthorizeDataAccess();
+      return (
+        'Reauthorize data access result: ' + JSON.stringify(result, null, 2)
+      );
+    }, 'Reauthorize data access failed');
+
+  _shareLinkWithShareDialog = () =>
+    this._runAction(async () => {
+      const canShow = await ShareDialog.canShow(SHARE_LINK_CONTENT);
+      if (!this._mounted) {
+        return '';
+      }
+      if (canShow) {
+        const {isCancelled, postId} =
+          await ShareDialog.show(SHARE_LINK_CONTENT);
+        if (isCancelled) {
+          return 'Share cancelled';
+        }
+        return postId
+          ? 'Share success with postId: ' + postId
+          : 'Share successful';
+      }
+      return 'Sharing is unavailable on this device';
+    }, 'Sharing failed');
 
   render() {
     return (
@@ -80,12 +118,23 @@ export default class App extends Component<{}> {
             Alert.alert(JSON.stringify(error || data, null, 2));
           }}
         />
-        <TouchableHighlight onPress={this._shareLinkWithShareDialog}>
+        <TouchableHighlight
+          accessibilityRole="button"
+          accessibilityState={{disabled: this.state.busy}}
+          disabled={this.state.busy}
+          onPress={this._shareLinkWithShareDialog}>
           <Text style={styles.buttonText}>Share link with ShareDialog</Text>
         </TouchableHighlight>
-        <TouchableHighlight onPress={this._reauthorizeDataAccess}>
+        <TouchableHighlight
+          accessibilityRole="button"
+          accessibilityState={{disabled: this.state.busy}}
+          disabled={this.state.busy}
+          onPress={this._reauthorizeDataAccess}>
           <Text style={styles.buttonText}>Reauthorize Data Access</Text>
         </TouchableHighlight>
+        <Text accessibilityLiveRegion="polite">
+          {this.state.busy ? 'Working…' : ''}
+        </Text>
       </View>
     );
   }


### PR DESCRIPTION
## Fixes and compatibility

Example-only behavior change; no library API change. Native SDK login-button behavior is unchanged. No screen-reader/device usability certification is claimed.

Guard repeated/interleaved example actions immediately, catch canShow and synchronous/asynchronous SDK errors, avoid presenting a dialog or updating state after unmount, and show useful cancellation/unavailable/no-post-ID feedback. Add button semantics, disabled accessibility state and polite loading feedback.

## Verification

- example: 10 focused checks passed.

Reject canShow and SDK calls; tap repeatedly/interleave actions; unmount while awaiting; return cancellation, unavailable sharing and success without a post ID. Verify feedback, busy reset, disabled semantics and no late UI work.

- Each PR was applied independently to baseline `8241b0b30523` and its focused checks passed. Temporary diagnostic fixtures were not added to the repository.
- Combined verification: existing Jest/plugin suite **18 tests / 4 suites**, source lint/formatting, root TypeScript, plugin build/lint, example TypeScript/lint and both release-mode Metro bundles passed.
- Combined native example: Android Debug build and unsigned iOS Simulator Debug build passed on RN 0.76.5. The compiled native source was compared with the reviewed source. Facebook SDK dependency constraints are unchanged.
- React Doctor reports no issues on the combined changes. Real Facebook login/sharing, device permission flows and assistive-technology interaction were not exercised; the public example is not configured for those end-to-end tests.

Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

No release-version bump or unrelated dependency upgrade is included.
