### PR TITLE
fix(packaging): include Android and Expo sources in Yarn packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "files": [
     "android/src/main/AndroidManifest.xml",
-    "android/src/main/java/",
+    "android/src/main/java/**/*",
     "android/build.gradle",
     "ios",
     "lib",
@@ -82,7 +82,7 @@
     "tsconfig.json",
     "app.plugin.js",
     "expo-module.config.json",
-    "plugin/build/"
+    "plugin/build/**/*"
   ],
   "peerDependencies": {
     "expo": ">=47.0.0",


### PR DESCRIPTION
## Fixes and compatibility

Include the Android Java sources and compiled Expo plugin when Yarn packs this package. No runtime API, SDK constraint or version changes.

The nested-directory entries in `files` are accepted by npm but do not recursively include those directories with Yarn 4.12.0. Use explicit recursive patterns for both paths. A Git dependency can otherwise install successfully while Android autolinking skips the module and `app.plugin.js` points at missing files.

## Verification

- Yarn 4.12.0 dry-run package listing before/after: the Android Java and `plugin/build` files are absent before and present after. On the combined source-review checkout this restores 31 files; the additional dialog helper belongs to a separate PR.
- `npm pack --ignore-scripts --dry-run --json` still includes both trees.
- The patch contains only two `files` entries and does not change native or JavaScript implementations.
Final consumer verification on RN 0.87.1: immutable installation/lint, both Android Debug variants, both unsigned iOS Simulator schemes, four production Metro bundles, 13 web targets and four extensions passed. All 301 installed non-metadata files match the pinned artifact. Android CLI configuration and generated PackageList register FBSDKPackage, and Gradle compiles its Java sources. This final pass includes the packaging correction in #692; the earlier build that silently skipped Android autolinking is not counted as integration verification. Real provider/device flows remain untested.

This was found during final Git-package verification, after the source and native example checks. No checked-in tests or snapshots were changed.
