### PR TITLE
fix(ci): [LOW] pin checkout action revisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   js-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -34,7 +34,7 @@ jobs:
   android-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -63,7 +63,7 @@ jobs:
   ios-build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Security issue

The CI and release workflows reference `actions/checkout` through mutable major-version tags. If that tag were moved or the upstream action were compromised, the workflows could execute changed code without any review in this repository. The release job has package-publishing privileges, which raises the impact of that trust.

## Fix

Pin every checkout use to the commit currently referenced by its existing major version:

- v6: `d23441a48e516b6c34aea4fa41551a30e30af803`
- v5: `fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09`

The comments retain the intended update channel for dependency tooling.

## Verification

- Resolved both commits from the official `actions/checkout` GitHub repository
- Confirmed all four workflow references are immutable 40-character SHAs
- `yarn prettier --parser yaml --check .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`
