### PR TITLE
fix(ci): [LOW] pin retry action revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           key: ${{ runner.os }}-android-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-js-yarn-v1
       - name: Install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 10
           retry_wait_seconds: 30
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-android-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-android-yarn-v1
       - name: Install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 10
           retry_wait_seconds: 30
@@ -98,7 +98,7 @@ jobs:
           key: ${{ runner.os }}-pods-v1-${{ hashFiles('RNFBSDKExample/ios/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-pods-v1
       - name: Install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 10
           retry_wait_seconds: 30


### PR DESCRIPTION
## Security issue

CI runs the third-party `nick-fields/retry@v3` action through a mutable tag. A moved or compromised tag could execute changed code in all platform jobs without a reviewed repository change.

## Fix

Pin all three uses to `ce71cc2ab81d554ebbe88c79ab5975992d79ba08`, the commit currently referenced by v3. The `# v3` comments retain update intent.

## Verification

- Resolved the SHA from the action's GitHub repository
- Confirmed every retry step uses the immutable 40-character SHA
- `yarn prettier --parser yaml --check .github/workflows/ci.yml`
- `git diff --check`
