### PR TITLE
fix(ci): [LOW] pin setup-java action revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           max_attempts: 3
           command: yarn install --frozen-lockfile
       - name: Install JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
## Security issue

The Android CI job executes `actions/setup-java@v5` through a mutable tag. A moved or compromised tag could change code executed by the workflow without a reviewed change here.

## Fix

Pin the action to `b6effb05e454b25005698d916606bdc6ffcbf961`, the commit currently referenced by the official v5 tag. The `# v5` comment preserves update intent.

## Verification

- Resolved the SHA from the official `actions/setup-java` repository
- Confirmed the workflow uses the immutable 40-character SHA
- `yarn prettier --parser yaml --check .github/workflows/ci.yml`
- `git diff --check`
