### PR TITLE
fix(ci): [LOW] pin setup-ruby action revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: iOS build configured to use current node
         run: echo "export NODE_BINARY=`which node`" > RNFBSDKExample/ios/.xcode.env.local
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: 3
       - name: Install cocoapods


### PR DESCRIPTION
## Security issue

The iOS CI job executes `ruby/setup-ruby@v1` through a mutable branch. A moved or compromised branch could change workflow code without any reviewed update in this repository.

## Fix

Pin the action to `95ef2b042f9d7a56d8268cba8559e2842e2ad01b`, the current commit of the official v1 branch. The `# v1` comment preserves the intended update channel.

## Verification

- Resolved the SHA from the official `ruby/setup-ruby` repository
- Confirmed the workflow uses the immutable 40-character SHA
- `yarn prettier --parser yaml --check .github/workflows/ci.yml`
- `git diff --check`
