### PR TITLE
fix(ci): [LOW] pin ccache action revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: gem install cocoapods
       - name: Install xcbeautify
         run: brew install xcbeautify
-      - uses: hendrikmuhs/ccache-action@v1
+      - uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1
         name: Xcode Compile Cache
         with:
           key: ${{ runner.os }}-v1 # makes a unique key w/related restore key internally


### PR DESCRIPTION
## Security issue

The iOS CI job executes the third-party `hendrikmuhs/ccache-action@v1` action through a mutable tag. A moved or compromised tag could run changed code without a reviewed repository update.

## Fix

Pin the action to `5ebbd400eff9e74630f759d94ddd7b6c26299639`, the commit referenced by the current official v1 annotated tag. The `# v1` comment preserves update intent.

## Verification

- Dereferenced the official annotated v1 tag to its commit
- Confirmed the workflow uses the immutable 40-character SHA
- `yarn prettier --parser yaml --check .github/workflows/ci.yml`
- `git diff --check`
