### PR TITLE
fix(ci): [LOW] pin semantic PR action revision

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -10,7 +10,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Security issue

The `pull_request_target` workflow executes `amannn/action-semantic-pull-request@v6` through a mutable tag while passing the repository token. A moved or compromised tag could therefore run changed code in a privileged workflow without a reviewed change here.

## Fix

Pin the action to `48f256284bd46cdaab1048c3721360e808335d50`, the commit currently referenced by v6. The `# v6` comment preserves update intent.

## Verification

- Resolved the SHA from the action's GitHub repository
- Confirmed the workflow uses the immutable 40-character SHA
- `yarn prettier --parser yaml --check .github/workflows/pr_title.yml`
- `git diff --check`
