### PR TITLE
fix(ci): [LOW] limit workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -6,6 +6,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Security issue

The CI and `pull_request_target` title-validation workflows rely on the repository's default `GITHUB_TOKEN` permissions. Those defaults are repository-configurable and may grant write access that neither workflow needs, increasing the impact of a compromised step.

## Fix

Declare least-privilege permissions explicitly:

- CI receives read-only repository contents access.
- PR-title validation receives read-only pull-request access, matching the action's documented requirement.

The release workflow already declares its required publishing permissions and is unchanged.

## Verification

- Cross-checked the semantic PR action's documented `pull-requests: read` requirement
- Confirmed every workflow now has explicit permissions
- `yarn prettier --parser yaml --check .github/workflows/ci.yml .github/workflows/pr_title.yml`
- `git diff --check`
