### PR TITLE
fix(android): [LOW] verify Gradle distribution

### DIFF
--- a/RNFBSDKExample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/RNFBSDKExample/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionSha256Sum=2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Security issue

The example Android build downloads the Gradle 8.10.2 distribution without configuring its published checksum. TLS is still used, but Gradle cannot reject altered distribution bytes before executing the build tool.

## Fix

Set `distributionSha256Sum` to Gradle's published SHA-256 for `gradle-8.10.2-all.zip`:

`2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6`

## Verification

- Fetched the checksum from `services.gradle.org/distributions/gradle-8.10.2-all.zip.sha256`
- Confirmed the committed wrapper JAR matches Gradle's published 8.10.2 wrapper checksum
- Ran `./gradlew --version` with a fresh temporary `GRADLE_USER_HOME`, exercising download and checksum validation
- `git diff --check`
