### PR TITLE
feat(android): declare package visibility for the Facebook and Messenger apps in the Expo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,8 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
 ```
 
 Unless you are managing your own native code, the config plugin must be configured per the following "API" section.
+
+On Android the plugin also declares [package visibility](https://developers.facebook.com/docs/android/troubleshooting/#faq_267321845055988) for the Facebook and Messenger apps (`com.facebook.katana` and `com.facebook.orca`), which Android 11+ requires before the SDK can reach them for login, sharing and app events attribution.
          
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 

--- a/plugin/build/withFacebookAndroid.js
+++ b/plugin/build/withFacebookAndroid.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setFacebookConfig = exports.withAndroidPermissions = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
+exports.withAndroidPermissions = exports.withFacebookManifest = exports.withFacebookAppIdString = void 0;
+exports.setFacebookConfig = setFacebookConfig;
 const config_1 = require("./config");
 const config_plugins_1 = require("@expo/config-plugins");
 const { buildResourceItem } = config_plugins_1.AndroidConfig.Resources;
@@ -8,6 +9,8 @@ const { removeStringItem, setStringItem } = config_plugins_1.AndroidConfig.Strin
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow, prefixAndroidKeys, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
 const FACEBOOK_ACTIVITY = 'com.facebook.FacebookActivity';
 const CUSTOM_TAB_ACTIVITY = 'com.facebook.CustomTabActivity';
+const FACEBOOK_APP_PACKAGE = 'com.facebook.katana';
+const MESSENGER_APP_PACKAGE = 'com.facebook.orca';
 const STRING_FACEBOOK_APP_ID = 'facebook_app_id';
 const STRING_FB_LOGIN_PROTOCOL_SCHEME = 'fb_login_protocol_scheme';
 const STRING_FACEBOOK_CLIENT_TOKEN = 'facebook_client_token';
@@ -96,6 +99,26 @@ function getCustomTabActivity() {
         },
     });
 }
+function ensurePackageVisibility(androidManifest) {
+    /**
+  <queries>
+      <package android:name="com.facebook.katana" />
+      <package android:name="com.facebook.orca" />
+  </queries>
+     */
+    const queries = androidManifest.manifest.queries ?? [];
+    const declaredPackages = queries.flatMap((query) => query.package ?? []);
+    const missingPackages = [FACEBOOK_APP_PACKAGE, MESSENGER_APP_PACKAGE].filter((packageName) => !declaredPackages.some((declaredPackage) => declaredPackage.$['android:name'] === packageName));
+    if (missingPackages.length > 0) {
+        queries.push({
+            package: missingPackages.map((packageName) => ({
+                $: { 'android:name': packageName },
+            })),
+        });
+    }
+    androidManifest.manifest.queries = queries;
+    return androidManifest;
+}
 function ensureFacebookActivity({ mainApplication, scheme, }) {
     if (Array.isArray(mainApplication.activity)) {
         // Remove all Facebook CustomTabActivities first
@@ -152,6 +175,7 @@ function setFacebookConfig(props, androidManifest) {
     const autoInitEnabled = (0, config_1.getFacebookAutoInitEnabled)(props);
     const autoLogAppEvents = (0, config_1.getFacebookAutoLogAppEvents)(props);
     const advertiserIdCollection = (0, config_1.getFacebookAdvertiserIDCollection)(props);
+    androidManifest = ensurePackageVisibility(androidManifest);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let mainApplication = getMainApplicationOrThrow(androidManifest);
     mainApplication = ensureFacebookActivity({ scheme, mainApplication });
@@ -194,4 +218,3 @@ function setFacebookConfig(props, androidManifest) {
     }
     return androidManifest;
 }
-exports.setFacebookConfig = setFacebookConfig;

--- a/plugin/src/__tests__/withFacebookAndroid-test.ts
+++ b/plugin/src/__tests__/withFacebookAndroid-test.ts
@@ -64,6 +64,24 @@ const filledManifest = `<manifest xmlns:android="http://schemas.android.com/apk/
 `;
 
 describe('Android facebook config', () => {
+  it('declares package visibility for the Facebook and Messenger apps', async () => {
+    let androidManifestJson =
+      await readAndroidManifestAsync(sampleManifestPath);
+
+    androidManifestJson = setFacebookConfig({}, androidManifestJson);
+    // Applying the config twice must not duplicate the declarations.
+    androidManifestJson = setFacebookConfig({}, androidManifestJson);
+
+    const declaredPackages = androidManifestJson.manifest.queries
+      .flatMap((query) => query.package ?? [])
+      .map((declaredPackage) => declaredPackage.$['android:name']);
+
+    expect(declaredPackages).toEqual([
+      'com.facebook.katana',
+      'com.facebook.orca',
+    ]);
+  });
+
   it(`returns null from all getters if no value provided`, () => {
     expect(getFacebookScheme({})).toBe(null);
     expect(getFacebookAppId({})).toBe(null);

--- a/plugin/src/withFacebookAndroid.ts
+++ b/plugin/src/withFacebookAndroid.ts
@@ -26,6 +26,8 @@ const {
 
 const FACEBOOK_ACTIVITY = 'com.facebook.FacebookActivity';
 const CUSTOM_TAB_ACTIVITY = 'com.facebook.CustomTabActivity';
+const FACEBOOK_APP_PACKAGE = 'com.facebook.katana';
+const MESSENGER_APP_PACKAGE = 'com.facebook.orca';
 const STRING_FACEBOOK_APP_ID = 'facebook_app_id';
 const STRING_FB_LOGIN_PROTOCOL_SCHEME = 'fb_login_protocol_scheme';
 const STRING_FACEBOOK_CLIENT_TOKEN = 'facebook_client_token';
@@ -138,6 +140,36 @@ function getCustomTabActivity() {
   }) as AndroidConfig.Manifest.ManifestActivity;
 }
 
+function ensurePackageVisibility(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+) {
+  /**
+<queries>
+    <package android:name="com.facebook.katana" />
+    <package android:name="com.facebook.orca" />
+</queries>
+   */
+  const queries = androidManifest.manifest.queries ?? [];
+  const declaredPackages = queries.flatMap((query) => query.package ?? []);
+  const missingPackages = [FACEBOOK_APP_PACKAGE, MESSENGER_APP_PACKAGE].filter(
+    (packageName) =>
+      !declaredPackages.some(
+        (declaredPackage) => declaredPackage.$['android:name'] === packageName,
+      ),
+  );
+
+  if (missingPackages.length > 0) {
+    queries.push({
+      package: missingPackages.map((packageName) => ({
+        $: {'android:name': packageName},
+      })),
+    });
+  }
+
+  androidManifest.manifest.queries = queries;
+  return androidManifest;
+}
+
 function ensureFacebookActivity({
   mainApplication,
   scheme,
@@ -231,6 +263,8 @@ export function setFacebookConfig(
   const autoInitEnabled = getFacebookAutoInitEnabled(props);
   const autoLogAppEvents = getFacebookAutoLogAppEvents(props);
   const advertiserIdCollection = getFacebookAdvertiserIDCollection(props);
+
+  androidManifest = ensurePackageVisibility(androidManifest);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let mainApplication = getMainApplicationOrThrow(androidManifest);


### PR DESCRIPTION
## Summary

Android 11+ (API 30) hides other installed apps unless the manifest declares them in `<queries>`. The Expo config plugin already handles the iOS side (`LSApplicationQueriesSchemes`), but it writes nothing equivalent for Android, so managed Expo projects end up with this warning on every launch:

```
W/com.facebook.internal.NativeProtocol: Apps that target Android API 30+ (Android 11+) cannot call Facebook native apps unless the package visibility needs are declared. Please follow https://developers.facebook.com/docs/android/troubleshooting/#faq_267321845055988 to make the declaration.
```

This PR makes `setFacebookConfig` add a `<queries>` block for `com.facebook.katana` (Facebook) and `com.facebook.orca` (Messenger), matching [Meta's Android troubleshooting guidance](https://developers.facebook.com/docs/android/troubleshooting/#faq_267321845055988).

## Why it matters

Looking at `facebook-core` 18.3.0, the SDK reaches the Facebook app from three places, and all of them need package visibility:

- `NativeProtocol`: native login and the share dialogs.
- `AttributionIdentifiers`: reads `content://com.facebook.katana.provider.AttributionIdProvider` to attach the attribution id to app events. Without it, attribution falls back to the advertising id alone.
- `RemoteServiceWrapper`: on-device event processing.

Package-level queries were chosen over the `<provider>` form from the docs because the SDK uses more than one authority in the same package (`PlatformProvider` for login/share, `AttributionIdProvider` for app events), and a package query covers all of them.

## Changes

- `plugin/src/withFacebookAndroid.ts`: new `ensurePackageVisibility`, called from `setFacebookConfig`. It only appends packages that are not already declared, so running the mod twice does not duplicate entries.
- `plugin/src/__tests__/withFacebookAndroid-test.ts`: test that both packages are declared and that applying the config twice keeps a single declaration of each.
- `README.md`: one line under "Expo installation" describing the behaviour.
- `plugin/build/withFacebookAndroid.js`: rebuilt output.

## Verification

- `yarn jest plugin`: 19 passed.
- `yarn validate:prettier`: clean.
- `eslint` on the touched files: clean (the 7 pre-existing errors in `plugin/src` on `master` are untouched).
- In a real Expo SDK 57 / RN 0.86 app, `expo config --type introspect` now emits the expected `<queries>` block alongside the existing browsable-intent query.